### PR TITLE
Add ability to preserve prefix and destdir

### DIFF
--- a/app/BuildEnv/Options.hs
+++ b/app/BuildEnv/Options.hs
@@ -89,9 +89,9 @@ data Plan
   -- | Compute a plan.
   = ComputePlan
       PlanInputs
-        -- ^ input needed to compute the plan
+        -- ^ Input needed to compute the plan.
       (Maybe FilePath)
-        -- ^ optional filepath at which to write out the computed plan
+        -- ^ Optional filepath at which to write out the computed plan.
 
   -- | Use an existing @plan.json@ by reading the given file.
   | UsePlan
@@ -117,16 +117,18 @@ data NewOrExisting
 -- | Information needed to perform a build.
 data Build
   = Build
-    { buildFetch      :: Fetch
+    { buildDirs       :: Dirs Raw
+      -- ^ The directories relevant for the build:
+      --
+      --  - fetched sources directory,
+      --  - build output directory structure.
+    , buildFetch      :: Fetch
       -- ^ How to obtain the fetched sources,
       -- including the build plan.
-    , buildFetchDescr :: FetchDescription
-      -- ^ Where the fetch sources are located,
-      -- and the build plan they correspond to.
+    , buildBuildPlan  :: Plan
+      -- ^ The build plan to follow.
     , buildStrategy   :: BuildStrategy
       -- ^ How to perform the build (see 'BuildStrategy').
-    , buildDestDir    :: DestDir Raw
-      -- ^ The output directory for the build.
     , userUnitArgs    :: ConfiguredUnit -> UnitArgs
       -- ^ Extra per-unit arguments.
     }

--- a/app/BuildEnv/Parse.hs
+++ b/app/BuildEnv/Parse.hs
@@ -359,10 +359,17 @@ build = do
         <> metavar "NUM_THREADS" )
 
     script :: Parser BuildStrategy
-    script = option (Script <$> str)
-        (  long "script"
-        <> help "Output a shell script containing build steps"
-        <> metavar "OUTFILE" )
+    script = do
+      scriptPath <-
+        option str
+          (  long "script"
+          <> help "Output a shell script containing build steps"
+          <> metavar "OUTFILE" )
+      useVariables <-
+        switch
+          (  long "variables"
+          <> help "Use variables in the shell script output" )
+      return $ Script { scriptPath, useVariables }
 
     optFetch :: Parser Fetch
     optFetch =
@@ -387,16 +394,12 @@ build = do
                    <> help "Installation destination directory"
                    <> value "/"
                    <> metavar "OUTDIR" )
-      preserveDirs <-
-        flag CanonicaliseDirs PreserveDirs
-          (  long "preserve-dirs"
-          <> help "Preserve prefix and destdir instead of canonicalising" )
       return $
         Dirs
           { fetchDir
           , destDir
           , prefix
-          , installDir = preserveDirs
+          , installDir = ()
           }
 
     -- TODO: we only support passing arguments for all units at once,

--- a/app/BuildEnv/Parse.hs
+++ b/app/BuildEnv/Parse.hs
@@ -63,15 +63,26 @@ options currWorkDir = do
 optCompiler :: Parser Compiler
 optCompiler =
     Compiler
-      <$> option str (long "ghc" <> value "ghc" <> help "'ghc' executable path" <> metavar "GHC")
-      <*> option str (long "ghc-pkg" <> value "ghc-pkg" <> help "'ghc-pkg' executable path" <> metavar "GHC-PKG")
+      <$> option str
+            (  long "ghc"
+            <> value "ghc"
+            <> help "'ghc' executable path"
+            <> metavar "GHC"
+            )
+      <*> option str
+            (  long "ghc-pkg"
+            <> value "ghc-pkg"
+            <> help "'ghc-pkg' executable path"
+            <> metavar "GHC-PKG"
+            )
 
 -- | Parse @cabal@ path.
 optCabal :: Parser Cabal
 optCabal = do
   cabalPath <-
     option str
-      (  long "cabal" <> value "cabal"
+      (  long "cabal"
+      <> value "cabal"
       <> help "'cabal' executable path"
       <> metavar "CABAL" )
   globalCabalArgs <-
@@ -84,7 +95,8 @@ optCabal = do
 optChangeWorkingDirectory :: FilePath -> Parser FilePath
 optChangeWorkingDirectory currWorkDir =
     option str
-      (  long "cwd" <> value currWorkDir
+      (  long "cwd"
+      <> value currWorkDir
       <> help "Set working directory"
       <> metavar "DIR" )
 
@@ -123,7 +135,11 @@ optMode =
   where
     optOutput :: Parser FilePath
     optOutput =
-      option str ( short 'p' <> long "plan" <> help "Output 'plan.json' file" <> metavar "OUTFILE" )
+      option str (  short 'p'
+                 <> long "plan"
+                 <> help "Output 'plan.json' file"
+                 <> metavar "OUTFILE"
+                 )
 
 
 -- | Description of which mode we are in.

--- a/app/BuildEnv/Parse.hs
+++ b/app/BuildEnv/Parse.hs
@@ -380,14 +380,18 @@ build = do
                    <> help "Installation prefix"
                    <> metavar "OUTDIR" )
       destDir <-
-        option str (  long "dest-dir"
+        option str (  long "destdir"
                    <> help "Installation destination directory"
                    <> value "/"
                    <> metavar "OUTDIR" )
+      preserveDirs <-
+        flag CanonicaliseDirs PreserveDirs
+          (  long "preserve-dirs"
+          <> help "Preserve prefix and destdir instead of canonicalising" )
       return $
         DestDir
           { destDir, prefix
-          , installDir = () -- computed after path canonicalisation
+          , installDir = preserveDirs
           }
 
     -- TODO: we only support passing arguments for all units at once,

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -49,14 +49,15 @@ main = do
       FetchMode ( FetchDescription { fetchDir, fetchInputPlan } ) newOrUpd -> do
         plan <- getPlan delTemp verbosity workDir compiler cabal fetchInputPlan
         doFetch verbosity cabal fetchDir True newOrUpd plan
-      BuildMode ( Build { buildFetchDescr = FetchDescription { fetchDir, fetchInputPlan }
-                        , buildFetch, buildStrategy, buildDestDir
+      BuildMode ( Build { buildBuildPlan
+                        , buildFetch, buildStrategy
+                        , buildDirs = buildDirs@( Dirs { fetchDir } )
                         , userUnitArgs } ) -> do
-        plan <- getPlan delTemp verbosity workDir compiler cabal fetchInputPlan
+        plan <- getPlan delTemp verbosity workDir compiler cabal buildBuildPlan
         case buildFetch of
           Prefetched     -> return ()
           Fetch newOrUpd -> doFetch verbosity cabal fetchDir False newOrUpd plan
-        buildPlan verbosity compiler fetchDir buildDestDir buildStrategy
+        buildPlan verbosity compiler buildDirs buildStrategy
           userUnitArgs plan
 
 -- | Generate the contents of @pkg.cabal@ and @cabal.project@ files, using

--- a/build-env.cabal
+++ b/build-env.cabal
@@ -58,6 +58,7 @@ common common
       , OverloadedStrings
       , StandaloneDeriving
       , StandaloneKindSignatures
+      , TypeOperators
       , ViewPatterns
 
     ghc-options:

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,11 @@ __does not__ insert additional quotation marks around `$myArgs`, which allows
 passing multiple arguments at once (this is crucial when one doesn't know
 the number of arguments ahead of time).
 
+If you want to set `--prefix` or `--destdir` to variables, you will want to
+pass the `--preserve-dirs` flag, which will skip the step that attempts to make
+these paths absolute. In that case, the variables should expand to absolute
+paths, as is usually required for `prefix` and `destdir`.
+
 ## Specifying packages
 
 Instead of passing the required packages through the command line,

--- a/readme.md
+++ b/readme.md
@@ -100,10 +100,11 @@ __does not__ insert additional quotation marks around `$myArgs`, which allows
 passing multiple arguments at once (this is crucial when one doesn't know
 the number of arguments ahead of time).
 
-If you want to set `--prefix` or `--destdir` to variables, you will want to
-pass the `--preserve-dirs` flag, which will skip the step that attempts to make
-these paths absolute. In that case, the variables should expand to absolute
-paths, as is usually required for `prefix` and `destdir`.
+If you want to set `--fetchdir`, `--prefix` or `--destdir` to variables,
+you should pass the `--preserve-dirs` flag, which will skip the step
+that attempts to make these paths absolute.  
+In that case, the variables should expand to absolute paths, as is usually
+required for `prefix` and `destdir`.
 
 ## Specifying packages
 

--- a/readme.md
+++ b/readme.md
@@ -101,10 +101,9 @@ passing multiple arguments at once (this is crucial when one doesn't know
 the number of arguments ahead of time).
 
 If you want to set `--fetchdir`, `--prefix` or `--destdir` to variables,
-you should pass the `--preserve-dirs` flag, which will skip the step
-that attempts to make these paths absolute.  
-In that case, the variables should expand to absolute paths, as is usually
-required for `prefix` and `destdir`.
+you should pass the `--variables` flag. This will set these to the values
+`$SOURCES`, `$PREFIX` and `$DESTDIR` in the output shell script, respectively.
+It will also use `$GHC` and `$GHCPKG` variables for the compiler.
 
 ## Specifying packages
 

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -73,7 +73,7 @@ import qualified Data.Set as Set
 
 -- directory
 import System.Directory
-  ( canonicalizePath, createDirectoryIfMissing
+  ( createDirectoryIfMissing
   , doesDirectoryExist, removeDirectoryRecursive
   )
 
@@ -343,21 +343,20 @@ cabalFetch verbosity cabal root pkgNmVer = do
 -- registered in the package database.
 buildPlan :: Verbosity
           -> Compiler
-          -> FilePath    -- ^ fetched sources directory (input)
-          -> DestDir Raw -- ^ installation directory structure (output)
+          -> Dirs Raw -- ^ directory structure
           -> BuildStrategy
           -> ( ConfiguredUnit -> UnitArgs )
              -- ^ extra arguments
           -> CabalPlan   -- ^ the build plan to execute
           -> IO ()
-buildPlan verbosity comp fetchDir0 destDir0
+buildPlan verbosity comp
+          destDir0
           buildStrat
           userUnitArgs
           cabalPlan
   = do
-    fetchDir <- canonicalizePath fetchDir0
-    dest@( DestDir { installDir, prefix, destDir } )
-      <- canonicalizeDestDir destDir0
+    dest@( Dirs { fetchDir, installDir, prefix, destDir } )
+      <- canonicalizeDirs destDir0
     createDirectoryIfMissing True installDir
 
     -- Create the package database directories (if they don't already exist).

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -88,7 +88,7 @@ import Data.Text
   ( Text )
 import qualified Data.Text    as Text
 import qualified Data.Text.IO as Text
-  ( appendFile, writeFile )
+  ( writeFile )
 
 -- build-env
 import BuildEnv.BuildOne
@@ -471,7 +471,7 @@ buildPlan verbosity comp fetchDir0 destDir0
                      else return emptyBuildScript
           let build = unitBuildScript cu
           return $ mbSetup <> build
-        Text.appendFile fp $ script scriptConfig $ mconcat buildScripts
+        Text.writeFile fp $ script scriptConfig $ mconcat buildScripts
 
   where
 

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -399,7 +399,7 @@ buildPlan verbosity comp
         compForOutput :: Compiler
         compForOutput
           | useVars
-          = Compiler { ghcPath = "$GHC", ghcPkgPath = "$GHCPKG" }
+          = Compiler { ghcPath = "${GHC}", ghcPkgPath = "${GHCPKG}" }
           | otherwise
           = comp
 

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -462,7 +462,7 @@ buildPlan verbosity comp fetchDir0 destDir0
       Script fp -> do
         let scriptConfig :: ScriptConfig
             scriptConfig =
-              ScriptConfig { quoteArgs = True, scriptStyle = hostStyle }
+              ScriptConfig { outputShell = True, scriptStyle = hostStyle }
 
         normalMsg verbosity $ "\nWriting build scripts to " <> Text.pack fp
         buildScripts <- for unitsToBuild \ ( cu, didSetup ) -> do

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -195,9 +195,9 @@ buildUnit verbosity
                           , "--builddir=" ++ buildDir
                           , setupVerbosity verbosity
                           ] ++ flagsArg
-                            ++ userConfigureArgs
                             ++ map ( dependencyArg plan unit )
                                 ( Configured.puDepends unit )
+                            ++ userConfigureArgs
                           ++ [ buildTarget unit ]
           setupExe = runCwdExe scriptCfg "Setup"
       logMessage verbosity Verbose $

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -39,7 +39,7 @@ import System.Directory
 
 -- filepath
 import System.FilePath
-  ( (</>) )
+  ( (</>), (<.>) )
 
 -- text
 import Data.Text
@@ -187,7 +187,7 @@ buildUnit verbosity
                             ++ map ( dependencyArg plan unit )
                                 ( Configured.puDepends unit )
                           ++ [ buildTarget unit ]
-          setupExe = runCwdExe (scriptStyle scriptCfg) "Setup"
+          setupExe = runCwdExe scriptCfg "Setup"
       logMessage verbosity Verbose $
         "Configuring " <> unitPrintableName
       logMessage verbosity Debug $
@@ -436,3 +436,20 @@ getPkgDir fetchDir ( ConfiguredUnit { puPkgName, puVersion, puPkgSrc } ) =
         = dir
         | otherwise
         = fetchDir </> pkgNameVer
+
+-- | Command to run an executable located the current working directory.
+runCwdExe :: ScriptConfig -> FilePath -> FilePath
+runCwdExe ( ScriptConfig { outputShell, scriptStyle } )
+  = pre . ext
+  where
+    pre
+      | not outputShell
+      , WinStyle <- scriptStyle
+      = id
+      | otherwise
+      = ( "./" <> )
+    ext
+      | WinStyle <- scriptStyle
+      = ( <.> "exe" )
+      | otherwise
+      = id

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -139,8 +139,8 @@ buildUnit :: Verbosity
           -> Compiler
           -> PkgDbDirs -- ^ package database directories (see 'getPkgDbDirs')
           -> PkgDir    -- ^ package directory (see 'getPkgDir')
-          -> DestDir Canonicalised
-               -- ^ installation directory structure
+          -> Dirs Canonicalised
+                      -- ^ directory structure
           -> UnitArgs -- ^ extra arguments for this unit
           -> Map UnitId PlanUnit -- ^ all dependencies in the build plan
           -> ConfiguredUnit -- ^ the unit to build
@@ -150,7 +150,7 @@ buildUnit verbosity
           ( PkgDbDirs { tempPkgDbDir, finalPkgDbDir
                       , tempPkgDbSem, finalPkgDbSem } )
           ( PkgDir { pkgNameVer, pkgDir } )
-          ( DestDir { installDir, prefix, destDir } )
+          ( Dirs { installDir, prefix, destDir } )
           ( UnitArgs { configureArgs = userConfigureArgs
                      , mbHaddockArgs = mbUserHaddockArgs
                      , registerArgs  = userGhcPkgArgs } )

--- a/src/BuildEnv/Config.hs
+++ b/src/BuildEnv/Config.hs
@@ -192,10 +192,10 @@ dirsForOutput :: Bool -- ^ use variables?
               -> Dirs ForOutput
 dirsForOutput useVars ( Dirs { fetchDir, destDir, prefix, installDir })
   | useVars
-  = Dirs { fetchDir   = "$SOURCES"
-         , prefix     = "$PREFIX"
-         , destDir    = "$DESTDIR"
-         , installDir = "$DESTDIR" </> "$PREFIX" }
+  = Dirs { fetchDir   = "${SOURCES}"
+         , prefix     = "${PREFIX}"
+         , destDir    = "${DESTDIR}"
+         , installDir = "${DESTDIR}" </> "${PREFIX}" }
   | otherwise
   = Dirs { fetchDir, destDir, prefix, installDir }
 

--- a/src/BuildEnv/Config.hs
+++ b/src/BuildEnv/Config.hs
@@ -195,7 +195,7 @@ dirsForOutput useVars ( Dirs { fetchDir, destDir, prefix, installDir })
   = Dirs { fetchDir   = "$SOURCES"
          , prefix     = "$PREFIX"
          , destDir    = "$DESTDIR"
-         , installDir = "$DESTDIR/$PREFIX" }
+         , installDir = "$DESTDIR" </> "$PREFIX" }
   | otherwise
   = Dirs { fetchDir, destDir, prefix, installDir }
 

--- a/src/BuildEnv/Config.hs
+++ b/src/BuildEnv/Config.hs
@@ -34,7 +34,7 @@ module BuildEnv.Config
 
     -- * OS specifics
   , Style(..), hostStyle
-  , runCwdExe, pATHSeparator
+  , pATHSeparator
 
   ) where
 
@@ -52,7 +52,7 @@ import System.Directory
 
 -- filepath
 import System.FilePath
-  ( (</>), (<.>), dropDrive )
+  ( (</>), dropDrive )
 
 -- text
 import Data.Text
@@ -212,11 +212,6 @@ cabalVerbosity (Verbosity _) = "-v3"
 data Style
   = PosixStyle
   | WinStyle
-
--- | Command to run an executable in the current working directory.
-runCwdExe :: Style -> FilePath -> FilePath
-runCwdExe PosixStyle exe = "./" <> exe
-runCwdExe WinStyle   exe = exe <.> "exe"
 
 -- | OS-dependent separator for the PATH environment variable.
 pATHSeparator :: Style -> String

--- a/src/BuildEnv/Script.hs
+++ b/src/BuildEnv/Script.hs
@@ -221,7 +221,7 @@ stepScript ( CallProcess ( CP { cwd, extraPATH, extraEnvVars, prog, args } ) ) =
     , "then true"
     , "else"
     , "  echo \"callProcess failed with non-zero exit code. Command:\""
-    , "  echo \"> " <> cmd <> " \""
+    , "  echo " <> cmd
     , "  exit \"${" <> resVar <> "}\""
     , "fi" ]
   where
@@ -246,7 +246,6 @@ stepScript ( CallProcess ( CP { cwd, extraPATH, extraEnvVars, prog, args } ) ) =
       = [  "  export PATH=$PATH:"
         <> Text.intercalate ":" (map q extraPATH)
         <> " ; \\" ]
-
 
     mkEnvVar :: (String, String) -> Text
     mkEnvVar (var,val) = "  export "

--- a/src/BuildEnv/Script.hs
+++ b/src/BuildEnv/Script.hs
@@ -261,12 +261,13 @@ stepScript ( CallProcess ( CP { cwd, extraPATH, extraEnvVars, prog, args } ) ) =
       = []
       | otherwise
       = [  "  export PATH=$PATH:"
-        <> Text.intercalate ":" (map q extraPATH)
+        <> Text.intercalate ":" (map Text.pack extraPATH) -- (already quoted)
         <> " ; \\" ]
 
     mkEnvVar :: (String, String) -> Text
     mkEnvVar (var,val) = "  export "
                       <> Text.pack var
-                      <> "=" <> q val <> " ; \\"
+                      <> "=" <> Text.pack val <> " ; \\"
+                                 -- (already quoted)
 stepScript (LogMessage str) =
   [ "echo " <> q str ]

--- a/src/BuildEnv/Script.hs
+++ b/src/BuildEnv/Script.hs
@@ -129,10 +129,16 @@ logMessage v msg_v msg
 -- | Configuration options for a 'BuildScript'.
 data ScriptConfig
   = ScriptConfig
-  { quoteArgs   :: !Bool
-    -- ^ Whether to add quotes around command-line arguments,
-    -- to avoid an argument with spaces being interpreted
-    -- as multiple arguments.
+  { outputShell :: !Bool
+    -- ^ Whether we are outputting a shell script.
+    --
+    -- Used for the following decisions:
+    --
+    --  - to add quotes around command-line arguments,
+    --    to avoid an argument with spaces being interpreted
+    --    as multiple arguments,
+    --  - to unconditionally add @./@ to run an executable
+    --    in the current working directory.
   , scriptStyle :: !Style
     -- ^ Whether to use Posix or Windows style conventions.
   }
@@ -141,7 +147,7 @@ data ScriptConfig
 hostRunCfg :: ScriptConfig
 hostRunCfg =
   ScriptConfig
-    { quoteArgs   = False
+    { outputShell = False
     , scriptStyle = hostStyle }
 
 -- | Quote a string, to avoid spaces causing the string
@@ -167,8 +173,8 @@ q t = "\"" <> fromString (escapeArg t) <> "\""
 -- No need to call this on the 'cwd' or 'prog' fields of 'CallProcess',
 -- as these will be quoted by the shell-script backend no matter what.
 quoteArg :: ( IsString r, Monoid r ) => ScriptConfig -> String -> r
-quoteArg ( ScriptConfig { quoteArgs } )
-  | quoteArgs
+quoteArg ( ScriptConfig { outputShell } )
+  | outputShell
   = q
   | otherwise
   = fromString


### PR DESCRIPTION
This adds the ability to preserve `--destdir` and `--prefix`, to be used when outputting a build script. This is gated behind the `preserve-dirs` flag. This allows passing variables as `prefix` and `destdir`, so that we don't attempt to turn them into nonsense absolute paths like `/home/xyz/$prefix`.