### PR TITLE
Refactor directory structure handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         mkdir -p localpkgs
         ( cd localpkgs ; cabal get distributive-0.6.2.1 )
-        cabal run exe:build-env -- build free --local distributive=localpkgs/distributive-0.6.2.1 -f sources -o install --script build_free.sh --variables -v2
+        cabal run exe:build-env -- build free --local distributive=localpkgs/distributive-0.6.2.1 -f sources --script build_free.sh --variables -v2
         mkdir -p build
         cp build_free.sh build/build_free.sh
         cp -a sources   build/srcs

--- a/app/BuildEnv/Options.hs
+++ b/app/BuildEnv/Options.hs
@@ -76,7 +76,7 @@ data PlanInputs
 -- and what build plan they correspond to.
 data FetchDescription
   = FetchDescription
-    { fetchDir       :: FilePath
+    { rawFetchDir    :: FilePath
       -- ^ Directory for fetched sources.
     , fetchInputPlan :: Plan
       -- ^ The build plan corresponding to the fetched sources.
@@ -117,11 +117,14 @@ data NewOrExisting
 -- | Information needed to perform a build.
 data Build
   = Build
-    { buildDirs       :: Dirs Raw
+    { buildRawPaths   :: Paths Raw
       -- ^ The directories relevant for the build:
       --
       --  - fetched sources directory,
-      --  - build output directory structure.
+      --  - build output directory structure
+      --
+      -- NB: the build directories are ignored if we are ouputting
+      -- a shell script containing variables.
     , buildFetch      :: Fetch
       -- ^ How to obtain the fetched sources,
       -- including the build plan.

--- a/src/BuildEnv/CabalPlan.hs
+++ b/src/BuildEnv/CabalPlan.hs
@@ -101,7 +101,7 @@ import qualified Data.Text as Text
 -- Build plans
 
 -- | Units in a Cabal @plan.json@ file.
-data CabalPlan = CabalPlan { planUnits :: [PlanUnit] }
+newtype CabalPlan = CabalPlan { planUnits :: [PlanUnit] }
 
 mapMaybePlanUnits :: (PlanUnit -> Maybe a) -> CabalPlan -> [a]
 mapMaybePlanUnits f (CabalPlan units) = mapMaybe f units
@@ -157,8 +157,8 @@ newtype AllowNewer = AllowNewer ( Set (Text, Text) )
 type PkgSpecs = Strict.Map PkgName PkgSpec
 
 -- | Constraints and flags for a package.
-data PkgSpec = PkgSpec { psConstraints :: Maybe Constraints
-                       , psFlags :: FlagSpec
+data PkgSpec = PkgSpec { psConstraints :: !( Maybe Constraints )
+                       , psFlags       :: !FlagSpec
                        }
   deriving stock Show
 
@@ -240,7 +240,7 @@ flagSpecIsEmpty (FlagSpec fs) = null fs
 --   - @Just fp@: specified by the @cabal@ file at the given path.
 data PkgSrc
   = Remote
-  | Local FilePath
+  | Local !FilePath
   deriving stock Show
 
 instance Semigroup PkgSrc where
@@ -272,8 +272,8 @@ newtype UnitId = UnitId { unUnitId :: Text }
     deriving newtype (Eq, Ord, FromJSON, FromJSONKey)
 
 data PlanUnit
-  = PU_Preexisting PreexistingUnit
-  | PU_Configured  ConfiguredUnit
+  = PU_Preexisting !PreexistingUnit
+  | PU_Configured  !ConfiguredUnit
   deriving stock Show
 
 planUnitUnitId :: PlanUnit -> UnitId
@@ -345,25 +345,25 @@ instance FromJSON PlanUnit where
 -- | Information about a built-in pre-existing unit (such as @base@).
 data PreexistingUnit
   = PreexistingUnit
-    { puId      :: UnitId
-    , puPkgName :: PkgName
-    , puVersion :: Version
-    , puDepends :: [UnitId]
+    { puId      :: !UnitId
+    , puPkgName :: !PkgName
+    , puVersion :: !Version
+    , puDepends :: ![UnitId]
     }
   deriving stock Show
 
 -- | Information about a unit: name, version, dependencies, flags.
 data ConfiguredUnit
   = ConfiguredUnit
-    { puId            :: UnitId
-    , puPkgName       :: PkgName
-    , puVersion       :: Version
-    , puComponentName :: ComponentName
-    , puFlags         :: FlagSpec
-    , puDepends       :: [UnitId]
-    , puExeDepends    :: [UnitId]
-    , puSetupDepends  :: [UnitId]
-    , puPkgSrc        :: PkgSrc
+    { puId            :: !UnitId
+    , puPkgName       :: !PkgName
+    , puVersion       :: !Version
+    , puComponentName :: !ComponentName
+    , puFlags         :: !FlagSpec
+    , puDepends       :: ![UnitId]
+    , puExeDepends    :: ![UnitId]
+    , puSetupDepends  :: ![UnitId]
+    , puPkgSrc        :: !PkgSrc
     }
   deriving stock Show
 
@@ -391,9 +391,9 @@ type UnitSpecs = Strict.Map PkgName (PkgSrc, PkgSpec, Set ComponentName)
 
 -- | The name of a cabal component, e.g. @lib:comp@.
 data ComponentName =
-  ComponentName { componentType :: ComponentType
+  ComponentName { componentType :: !ComponentType
                    -- ^ What's before the colon, e.g. @lib@, @exe@, @setup@...
-                , componentName :: Text
+                , componentName :: !Text
                    -- ^ The actual name of the component
                 }
     deriving stock (Eq, Ord, Show)

--- a/src/BuildEnv/Config.hs
+++ b/src/BuildEnv/Config.hs
@@ -12,7 +12,7 @@
 -- Configuration options for @build-env@
 module BuildEnv.Config
   ( -- * Build strategy
-    BuildStrategy(..)
+    BuildStrategy(..), RunStrategy(..)
 
    -- * Passing arguments
   , Args, UnitArgs(..)
@@ -21,8 +21,9 @@ module BuildEnv.Config
   , Compiler(..), Cabal(..)
 
     -- * Directory structure
-  , Dirs(..), PathType(..), StagedPath
-  , canonicalizeDirs, dirsForOutput
+  , Paths(..), BuildPaths(..)
+  , PathUsability(..)
+  , canonicalizePaths
 
     -- ** Handling of temporary directories
   , TempDirPermanence(..)
@@ -65,26 +66,31 @@ import qualified Data.Text.IO as Text
 
 -- | Build strategy for 'buildPlan'.
 data BuildStrategy
-  -- | Topologically sort the cabal build plan, and build the
-  -- packages in sequence.
-  = TopoSort
-  -- | Asynchronously build all the packages, with each package
-  -- waiting on its dependencies.
-  | Async Word8
+  -- | Execute the build plan right away, in 'IO'.
+  = Execute RunStrategy
   -- | Output a build script that can be run later.
   | Script
-    { scriptPath :: FilePath
+    { scriptPath   :: !FilePath
       -- ^ Output path at which to write the build script.
-    , useVariables :: Bool
-      -- ^ Replace various values with variables, so that
-      -- they can be set before running the build script.
+    , useVariables :: !Bool
+      -- ^ Should the output shell script use variables, or baked in paths?
       --
-      -- Values:
+      -- Variables are:
       --
       --  - @GHC@ and @GHC-PKG@,
       --  - fetched sources directory @SOURCES@,
       --  - @PREFIX@ and @DESTDIR@.
     }
+  deriving stock Show
+
+-- | How to execute a build plan.
+data RunStrategy
+  -- | Topologically sort the cabal build plan, and build the
+  -- packages in sequence.
+  = TopoSort
+  -- | Asynchronously build all the packages, with each package
+  -- waiting on its dependencies.
+  | Async !Word8
   deriving stock Show
 
 --------------------------------------------------------------------------------
@@ -95,12 +101,12 @@ type Args = [String]
 
 -- | Arguments specific to a unit.
 data UnitArgs =
-  UnitArgs { configureArgs :: Args
+  UnitArgs { configureArgs :: !Args
                -- ^ Arguments to @Setup configure@.
-           , mbHaddockArgs :: Maybe Args
+           , mbHaddockArgs :: !(Maybe Args)
                -- ^ Arguments to @Setup haddock@.
                -- @Nothing@ means: skip @Setup haddock@.
-           , registerArgs  :: Args
+           , registerArgs  :: !Args
                -- ^ Arguments to @ghc-pkg register@.
            }
   deriving stock Show
@@ -109,8 +115,8 @@ data UnitArgs =
 -- GHC & cabal-install
 
 -- | Path to the @cabal-install@ executable.
-data Cabal = Cabal { cabalPath :: FilePath
-                   , globalCabalArgs :: Args
+data Cabal = Cabal { cabalPath       :: !FilePath
+                   , globalCabalArgs :: !Args
                      -- ^ Arguments to pass to all @cabal@ invocations,
                      -- before any @cabal@ command.
                    }
@@ -118,86 +124,105 @@ data Cabal = Cabal { cabalPath :: FilePath
 
 -- | Paths to the @ghc@ and @ghc-pkg@ executables.
 data Compiler =
-  Compiler { ghcPath    :: FilePath
-           , ghcPkgPath :: FilePath
+  Compiler { ghcPath    :: !FilePath
+           , ghcPkgPath :: !FilePath
            }
   deriving stock Show
 
 --------------------------------------------------------------------------------
 -- Directory structure
 
--- | The directory structure relevant to a build. These are:
---
--- - the input fetched sources directory
--- - the build output directory structure: @destdir@ and @prefix@,
---   which determine @installdir@.
---
--- Meaning of the type parameter:
---
--- - 'Raw': filepaths can be relative.
--- - 'Canonicalised': the filepaths must be absolute.
--- - 'ForOutput': filepaths may be variables (when outputting a shell script).
-type Dirs :: PathType -> Type
-data Dirs pathTy =
-  Dirs
-    { fetchDir    :: FilePath
-      -- ^ Input fetched sources directory (build input).
-    , destDir     :: FilePath
-      -- ^ Output build @destdir@.
-    , prefix      :: FilePath
-      -- ^ Output build @prefix@.
-    , installDir  :: StagedPath pathTy
-      -- ^ - 'Raw' stage: trivial value.
-      --   - 'Canonicalised' stage: the output installation directory @destdir/prefix@.
+-- | The directory structure relevant to preparing and carrying out
+-- a build plan.
+type Paths :: PathUsability -> Type
+data Paths use
+  = Paths
+    { fetchDir   :: !FilePath
+       -- ^ Input fetched sources directory.
+    , buildPaths :: !(BuildPaths use)
+      -- ^ Output build directory structure.
     }
 
-deriving stock instance Show (StagedPath pathTy) => Show (Dirs pathTy)
+-- | The directory structure relevant to executing a build plan.
+type BuildPaths :: PathUsability -> Type
+data family BuildPaths use
+data instance BuildPaths Raw
+  = RawBuildPaths
+    { rawDestDir :: !FilePath
+      -- ^ Raw output build @destdir@ (might be relative).
+    , rawPrefix  :: !FilePath
+      -- ^ Raw output build @prefix@ (might be relative).
+    }
+data instance BuildPaths ForPrep
+  = NoBuildPathsForPrep
+    -- ^ Placeholder to ensure that no build paths are used
+    -- during the build preparation stage.
+data instance BuildPaths ForBuild
+  = BuildPaths
+    { compiler   :: !Compiler
+      -- ^ Which @ghc@ and @ghc-pkg@ to use.
+    , destDir    :: !FilePath
+      -- ^ Output build @destdir@ (absolute).
+    , prefix     :: !FilePath
+      -- ^ Output build @prefix@ (absolute).
+    , installDir :: !FilePath
+      -- ^ Output installation directory @destdir/prefix@ (absolute).
+    }
 
-data PathType = Raw | Canonicalised | ForOutput
+-- | The appropriate stage at which to use a filepath.
+data PathUsability
+  -- | We have just parsed filepaths. They need to be canonicalised
+  -- before they can be used.
+  = Raw
+  -- | The filepaths have been canonicalised.
+  --
+  -- They are now suitable for preparatory build instructions,
+  -- but not for performing the build.
+  | ForPrep
+  -- | The paths are suitable for performing the build.
+  | ForBuild
 
--- | We need to canonicalise paths before computing an installation directory.
---
--- This type family keeps track of this canonicalisation step.
-type StagedPath :: PathType -> Type
-type family StagedPath pathTy where
-  StagedPath Raw           = ()
-  StagedPath Canonicalised = FilePath
-  StagedPath ForOutput     = FilePath
-
--- | Canonicalise 'Dirs', computing the appropriate
--- installation directory @destdir/prefix@.
-canonicalizeDirs :: Dirs Raw -> IO (Dirs Canonicalised)
-canonicalizeDirs ( Dirs { fetchDir = fetchDir0
-                        , destDir  = destDir0
-                        , prefix   = prefix0 } )
+-- | Canonicalise raw 'Paths', computing the appropriate directory structure
+-- for preparing a build and executing a build.
+canonicalizePaths :: Compiler
+                  -> BuildStrategy
+                  -> Paths Raw
+                  -> IO ( Paths ForPrep, Paths ForBuild )
+canonicalizePaths compiler buildStrat
+  ( Paths
+    { fetchDir   = fetchDir0
+    , buildPaths = RawBuildPaths { rawPrefix, rawDestDir } } )
   = do
-      fetchDir   <- canonicalizePath fetchDir0
-      prefix     <- canonicalizePath prefix0
-      destDir    <- canonicalizePath destDir0
-      installDir <- canonicalizePath ( destDir0 </> dropDrive prefix )
-        -- We must use dropDrive here. Quoting from the documentation of (</>):
-        --
-        --   If the second path starts with a path separator or a drive letter,
-        --   then (</>) returns the second path.
-        --
-        -- We don't want that, as we *do* want to concatenate both paths.
-      return $ Dirs { fetchDir, destDir, prefix, installDir }
-
--- | Compute the directory structure we should use for output.
---
--- Replaces everything with variables if the boolean is 'True'; otherwise
--- returns the input directory structure.
-dirsForOutput :: Bool -- ^ use variables?
-              -> Dirs Canonicalised
-              -> Dirs ForOutput
-dirsForOutput useVars ( Dirs { fetchDir, destDir, prefix, installDir } )
-  | useVars
-  = Dirs { fetchDir   = "${SOURCES}"
-         , prefix     = "${PREFIX}"
-         , destDir    = "${DESTDIR}"
-         , installDir = "${DESTDIR}" </> "${PREFIX}" }
-  | otherwise
-  = Dirs { fetchDir, destDir, prefix, installDir }
+      fetchDir <- canonicalizePath fetchDir0
+      forBuild <-
+        case buildStrat of
+          Script { useVariables }
+            | useVariables
+            -> return $
+                Paths { fetchDir   = "${SOURCES}"
+                      , buildPaths =
+                        BuildPaths
+                          { prefix     = "${PREFIX}"
+                          , destDir    = "${DESTDIR}"
+                          , installDir = "${DESTDIR}" </> "${PREFIX}"
+                          , compiler =
+                            Compiler { ghcPath = "${GHC}"
+                                     , ghcPkgPath = "${GHCPKG}" } } }
+          _don'tUseVars -> do
+            prefix     <- canonicalizePath rawPrefix
+            destDir    <- canonicalizePath rawDestDir
+            installDir <- canonicalizePath ( rawDestDir </> dropDrive prefix )
+              -- We must use dropDrive here. Quoting from the documentation of (</>):
+              --
+              --   If the second path starts with a path separator or a drive letter,
+              --   then (</>) returns the second path.
+              --
+              -- We don't want that, as we *do* want to concatenate both paths.
+            return $ Paths { fetchDir
+                           , buildPaths =
+                             BuildPaths { compiler, destDir, prefix, installDir } }
+      return $
+        ( Paths { fetchDir, buildPaths = NoBuildPathsForPrep }, forBuild )
 
 -- | How to handle deletion of temporary directories.
 data TempDirPermanence

--- a/src/BuildEnv/Script.hs
+++ b/src/BuildEnv/Script.hs
@@ -110,9 +110,9 @@ data BuildStep
   -- | Call a processs with the given arguments.
   = CallProcess CallProcess
   -- | Create the given directory.
-  | CreateDir FilePath
+  | CreateDir   FilePath
   -- | Log a message.
-  | LogMessage String
+  | LogMessage  String
 
 -- | Declare a build step.
 step :: BuildStep -> BuildScript
@@ -144,7 +144,7 @@ data ScriptOutput
   = Run
   -- | Generate a shell script.
   | Shell
-    { useVariables :: Bool
+    { useVariables :: !Bool
       -- ^ Replace various values with variables, so that
       -- they can be set before running the build script.
       --

--- a/src/BuildEnv/Utils.hs
+++ b/src/BuildEnv/Utils.hs
@@ -71,26 +71,26 @@ import BuildEnv.Config
 -- | The path of a program to run.
 data ProgPath
   -- | An absolute path, or an executable in @PATH@.
-  = AbsPath { progPath :: FilePath }
+  = AbsPath { progPath :: !FilePath }
   -- | A relative path. What it is relative to depends on context.
-  | RelPath { progPath :: FilePath }
+  | RelPath { progPath :: !FilePath }
 
 -- | Arguments to 'callProcess'.
 data CallProcess
   = CP
-  { cwd          :: FilePath
+  { cwd          :: !FilePath
      -- ^ Working directory.
-  , extraPATH    :: [FilePath]
+  , extraPATH    :: ![FilePath]
      -- ^ Absolute filepaths to add to PATH.
-  , extraEnvVars :: [(String, String)]
-     -- ^ Extra environment variables to add before running the command.
-  , prog         :: ProgPath
+  , extraEnvVars :: ![(String, String)]
+     -- ^ Extra envi!ronment variables to add before running the command.
+  , prog         :: !ProgPath
      -- ^ The program to run.
      --
      -- If it's a relative path, it should be relative to the @cwd@ field.
-  , args         :: Args
+  , args         :: !Args
      -- ^ Arguments to the program.
-  , sem          :: AbstractQSem
+  , sem          :: !AbstractQSem
      -- ^ Lock to take when calling the process
      -- and waiting for it to return, to avoid
      -- contention in concurrent situations.


### PR DESCRIPTION
This patch enforces a separation between filepaths used when preparing a build vs when actually performing a build, which is important if we are to output a relocatable shell script.
Now all the logic to change paths into variables is done in one place.

This also adds a default value for the `--prefix` argument, as it gets ignored if outputting a shell script using variables, so it's annoying to require it. It's not ideal as it's better to give an error if the user doesn't provide it in the other mode, but due to the applicative nature of `optparse-applicative` there isn't a straightforward way to do that (and the hacks I tried lead to poor help text).