### PR TITLE
Include exeDepends for datadir envvars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
     - name: "Build executable"
       run: cabal build exe:build-env
 
+    - name: "Build 'haskell-src-exts' (test build-tool-depends datadir)"
+      working-directory: ./tests/ExeDataDir
+      run: |
+        cabal run exe:build-env -- build haskell-src-exts -f sources -o install -v2
+
     - name: "Relocate and run a build script for 'free' (with local 'distributive')"
       working-directory: ./tests/RelocatableScript
       if: runner.os != 'Windows'

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -217,12 +217,14 @@ buildUnit verbosity
              -- dependencies during the build.
            , extraPATH = [ quoteArg scriptCfg $ installDir </> "bin" ]
 
-              -- Specify the data directories for all dependencies.
+              -- Specify the data directories for all dependencies,
+              -- including executable dependencies (see (**)).
+              -- This is important so that e.g. 'happy' can find its datadir.
            , extraEnvVars =
                [ ( mangledPkgName depName <> "_datadir"
                  , quoteArg scriptCfg $
                    installDir </> Text.unpack (pkgNameVersion depName depVer) )
-               | depUnitId <- Configured.puDepends unit
+               | depUnitId <- unitDepends unit -- (**) depends ++ exeDepends
                , let dep     = lookupDependency unit depUnitId plan
                      depName = planUnitPkgName dep
                      depVer  = planUnitVersion dep
@@ -455,7 +457,7 @@ type role PkgDir representational
   -- Don't allow accidentally passing a @PkgDir ForPrep@ where one expects
   -- a @PkgDir ForBuild@.
 
--- | Compute the package directory location. 
+-- | Compute the package directory location.
 getPkgDir :: FilePath
               -- ^ Working directory
               -- (used only to relativise paths to local packages).

--- a/tests/ExeDataDir/.gitignore
+++ b/tests/ExeDataDir/.gitignore
@@ -1,0 +1,3 @@
+install/
+sources/
+*.json


### PR DESCRIPTION
We weren't setting the `datadir` environment variables for `build-tool-depends`. This fixes that (and adds a test).