### PR TITLE
Fix handling of datadir

### DIFF
--- a/app/BuildEnv/Parse.hs
+++ b/app/BuildEnv/Parse.hs
@@ -470,9 +470,8 @@ build = do
     optHaddockArgs :: Parser ( Maybe ( ConfiguredUnit -> Args ) )
     optHaddockArgs = do
       doHaddock <-
-        bool False True <$>
-          switch (  long "haddock"
-                 <> help "Generate haddock documentation" )
+        switch (  long "haddock"
+               <> help "Generate haddock documentation" )
       args <- many $
         option str (  long "haddock-arg"
                    <> help "Pass argument to 'Setup haddock'"

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,33 @@ $ build-env build -p lens-plan.json -f sources -o install -j8
 Being able to separate these steps affords us some extra flexibility, as
 subsequent sections will explain.
 
+## What does `build-env` do?
+
+- **plan:** `build-env` calls `cabal build --dry-run` on a dummy
+  project with the dependencies and constraints that were asked for.  
+  This produces a Cabal plan in the form of a `plan.json`, which `build-env`
+  parses.  
+  **Required executables:** `cabal`, `ghc`.
+- **fetch:** `build-env` calls `cabal get` on each package in the build plan.  
+  **Required executables:** `cabal`.
+- **build:** `build-env` builds the dependencies by compiling their `Setup`
+  scripts, and calling `Setup configure`, `Setup build`,
+  `Setup haddock` (optional), `Setup copy`, and, for libraries, `Setup register`
+  and `ghc-pkg register`.  
+  **Required executables:** `ghc`, `ghc-pkg`.
+
+Note that, when building packages, `build-env` passes the following arguments
+to the `Setup` script:
+
+  - `with-compiler`, `prefix` and `destdir` options supplied by the user,
+  - the default `datadir` option,
+  - `cid`, `datasubdir` and `builddir` options supplied by `build-env`,
+  - package flags and `dependency` arguments, obtained from the build plan,
+  - `<pkg>_datadir` environment variables supplied by `build-env`.
+
+Problems will likely arise if you pass extra configure arguments that override
+any of these.
+
 ## Deferred builds
 
 When working in a hermetic build environment, we might need to compute a build

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -361,7 +361,7 @@ buildPlan verbosity workDir
           userUnitArgs
           cabalPlan
   = do
-    let BuildPaths { compiler, prefix, destDir, installDir }
+    let paths@( BuildPaths { compiler, prefix, destDir, installDir } )
          = buildPaths pathsForBuild
     -- Create the temporary package database, if it doesn't already exist.
     -- We also create the final installation package database,
@@ -407,19 +407,19 @@ buildPlan verbosity workDir
 
         -- Setup the package for this unit.
         unitSetupScript :: ConfiguredUnit -> IO BuildScript
-        unitSetupScript pu@(ConfiguredUnit { puSetupDepends }) = do
+        unitSetupScript pu = do
           let pkgDirForPrep  = getPkgDir workDir pathsForPrep  pu
               pkgDirForBuild = getPkgDir workDir pathsForBuild pu
           setupPackage verbosity compiler
-            pkgDbDirsForBuild pkgDirForPrep pkgDirForBuild
-            puSetupDepends
+            paths pkgDbDirsForBuild pkgDirForPrep pkgDirForBuild
+            depMap pu
 
         -- Build and install this unit.
         unitBuildScript :: ConfiguredUnit -> BuildScript
         unitBuildScript pu =
           let pkgDirForBuild = getPkgDir workDir pathsForBuild pu
           in buildUnit verbosity compiler
-                (buildPaths pathsForBuild) pkgDbDirsForBuild pkgDirForBuild
+                paths pkgDbDirsForBuild pkgDirForBuild
                 (userUnitArgs pu)
                 depMap pu
 

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -185,7 +185,7 @@ buildUnit verbosity
       let env =
             [ ( mangledPkgName depName <> "_datadir"
               , quoteArg scriptCfg $
-                installDir </> Text.unpack (pkgNameVersion depName depVer) )
+                installDir </> "share" </> Text.unpack (pkgNameVersion depName depVer) )
             | depUnitId <- unitDepends unit -- (**) depends ++ exeDepends
             , let dep     = lookupDependency unit depUnitId plan
                   depName = planUnitPkgName dep


### PR DESCRIPTION
Fix two bugs in datadir handling: 

*  The default datadir path is `<prefix>/share/<pkg>-<ver>`, not `<prefix>/<pkg>-<ver>`
* The datadirs path variables must be passed to both `Setup configure` and `Setup build`.
