### PR TITLE
Allow refining a build to a subset of units

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,17 @@ jobs:
     - name: "Build executable"
       run: cabal build exe:build-env
 
+    - name: "Refine a build"
+      working-directory: ./tests/Refine
+      run: |
+        cabal run exe:build-env -- build shake -f sources -o install -v2 --only random
+        ghc-pkg --package-db=install/package.conf field random id
+
     - name: "Build 'haskell-src-exts' (test build-tool-depends datadir)"
       working-directory: ./tests/ExeDataDir
       run: |
         cabal run exe:build-env -- build haskell-src-exts -f sources -o install -v2
+        ghc-pkg --package-db=install/package.conf field haskell-src-exts id
 
     - name: "Relocate and run a build script for 'free' (with local 'distributive')"
       working-directory: ./tests/RelocatableScript

--- a/app/BuildEnv/Options.hs
+++ b/app/BuildEnv/Options.hs
@@ -8,6 +8,10 @@
 -- expected by the command-line interface of @build-env@.
 module BuildEnv.Options where
 
+-- containers
+import Data.Set
+  ( Set )
+
 -- build-env
 import BuildEnv.CabalPlan
 import BuildEnv.Config
@@ -132,6 +136,9 @@ data Build
       -- ^ The build plan to follow.
     , buildStrategy   :: BuildStrategy
       -- ^ How to perform the build (see 'BuildStrategy').
+    , mbOnlyDepsOf    :: Maybe ( Set PkgName )
+      -- ^ @Just pkgs@ <=> only build @pkgs@ (and their dependencies).
+      --   @Nothing@ <=> build all units in the build plan.
     , userUnitArgs    :: ConfiguredUnit -> UnitArgs
       -- ^ Extra per-unit arguments.
     }

--- a/tests/Refine/.gitignore
+++ b/tests/Refine/.gitignore
@@ -1,0 +1,3 @@
+install/
+sources/
+*.json


### PR DESCRIPTION
This addresses issue #11, allowing a build plan to be refined so that we only build a subset of the units.