### PR TITLE
Progress indicators

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,6 +5,8 @@ import Control.Monad
   ( guard )
 import Data.Foldable
   ( for_ )
+import System.IO
+  ( BufferMode(..), hSetBuffering, stdout )
 
 -- bytestring
 import qualified Data.ByteString.Lazy as Lazy.ByteString
@@ -40,6 +42,7 @@ main = do
   currentDir <- getCurrentDirectory
   Opts { compiler, cabal, mode, verbosity, delTemp, workDir }
     <- runOptionsParser currentDir
+  hSetBuffering stdout $ BlockBuffering Nothing
   withCurrentDirectory workDir $
     case mode of
       PlanMode { planModeInputs, planOutput } -> do

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -103,7 +103,6 @@ import qualified BuildEnv.CabalPlan as Configured
 import BuildEnv.Config
 import BuildEnv.Script
   ( BuildScript, ScriptOutput(..), ScriptConfig(..)
-  , Counter(..)
   , emptyBuildScript
   , executeBuildScript, script
   , createDir, logMessage
@@ -155,7 +154,7 @@ computePlan delTemp verbosity comp cabal ( CabalFilesContents { cabalContents, p
             , cabalVerbosity verbosity ]
     debugMsg verbosity $
       Text.unlines $ "cabal" : map ( ("  " <>) . Text.pack ) cabalBuildArgs
-    callProcessInIO $
+    callProcessInIO Nothing $
       CP { cwd          = dir
          , prog         = AbsPath $ cabalPath cabal
          , args         = cabalBuildArgs
@@ -328,7 +327,7 @@ cabalFetch verbosity cabal root pkgNmVer = do
                  [ "get"
                  , pkgNmVer
                  , cabalVerbosity verbosity ]
-    callProcessInIO $
+    callProcessInIO Nothing $
       CP { cwd          = root
          , prog         = AbsPath $ cabalPath cabal
          , args

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -219,7 +219,8 @@ buildUnit verbosity
               -> []
               | otherwise
               -> [ "--flags=" ++ quoteArg scriptCfg ( Text.unpack (showFlagSpec flags) ) ]
-          buildDir = "dist" </> thisUnitId
+          buildDir = quoteArg scriptCfg -- Quote to escape \ on Windows.
+                   $ "dist" </> thisUnitId
             -- Set a different build directory for each unit,
             -- to avoid clashes when building multiple units from the same
             -- package concurrently.

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -350,7 +350,8 @@ buildUnit verbosity
 
         _notALib -> return ()
 
-      logMessage verbosity Normal $ "Installed " <> unitPrintableName
+      logMessage verbosity Normal $ "Finished building " <> unitPrintableName
+      reportProgress
 
 -- | The argument @-package-id PKG_ID@.
 unitIdArg :: UnitId -> String

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -351,7 +351,7 @@ buildUnit verbosity
         _notALib -> return ()
 
       logMessage verbosity Normal $ "Finished building " <> unitPrintableName
-      reportProgress
+      reportProgress verbosity
 
 -- | The argument @-package-id PKG_ID@.
 unitIdArg :: UnitId -> String

--- a/src/BuildEnv/Config.hs
+++ b/src/BuildEnv/Config.hs
@@ -34,6 +34,9 @@ module BuildEnv.Config
   , quietMsg, normalMsg, verboseMsg, debugMsg
   , ghcVerbosity, ghcPkgVerbosity, cabalVerbosity, setupVerbosity
 
+    -- * Reporting progress
+  , Counter(..)
+
     -- * OS specifics
   , Style(..), hostStyle
   , pATHSeparator
@@ -45,6 +48,8 @@ import Control.Monad
   ( when )
 import Data.Kind
   ( Type )
+import Data.IORef
+  ( IORef )
 import Data.Word
   ( Word16 )
 import System.IO
@@ -299,6 +304,18 @@ cabalVerbosity (Verbosity _) = "-v3"
 ghcVerbosity    = cabalVerbosity
 ghcPkgVerbosity = cabalVerbosity
 setupVerbosity  = cabalVerbosity
+
+--------------------------------------------------------------------------------
+-- Reporting progress.
+
+-- | A counter to measure progress, as units are compiled.
+data Counter =
+  Counter
+    { counterRef  :: !( IORef Word )
+      -- ^ The running count.
+    , counterMax :: !Word
+      -- ^ The maximum that we're counting up to.
+    }
 
 --------------------------------------------------------------------------------
 -- Posix/Windows style differences.

--- a/src/BuildEnv/Config.hs
+++ b/src/BuildEnv/Config.hs
@@ -47,6 +47,8 @@ import Data.Kind
   ( Type )
 import Data.Word
   ( Word16 )
+import System.IO
+  ( hFlush, stdout )
 
 -- directory
 import System.Directory
@@ -275,26 +277,28 @@ pattern Verbose = Verbosity 2
 pattern Debug   = Verbosity 3
 
 quietMsg, normalMsg, verboseMsg, debugMsg :: Verbosity -> Text -> IO ()
-quietMsg   v msg = when (v >= Quiet  ) $ Text.putStrLn msg
-normalMsg  v msg = when (v >= Normal ) $ Text.putStrLn msg
-verboseMsg v msg = when (v >= Verbose) $ Text.putStrLn msg
-debugMsg   v msg = when (v >= Debug  ) $ Text.putStrLn msg
+quietMsg   v msg = when (v >= Quiet  ) $ putMsg msg
+normalMsg  v msg = when (v >= Normal ) $ putMsg msg
+verboseMsg v msg = when (v >= Verbose) $ putMsg msg
+debugMsg   v msg = when (v >= Debug  ) $ putMsg msg
+
+-- | Write the text to @stdout@, and flush.
+putMsg :: Text -> IO ()
+putMsg msg = do
+  Text.putStrLn msg
+  hFlush stdout
 
 ghcVerbosity, ghcPkgVerbosity, cabalVerbosity, setupVerbosity
   :: Verbosity -> String
-ghcVerbosity (Verbosity i)
-  | i <= 1
-  = "-v0"
-  | otherwise
-  = "-v1"
-ghcPkgVerbosity = ghcVerbosity
-setupVerbosity  = ghcVerbosity
 cabalVerbosity (Verbosity i)
   | i <= 1
   = "-v0"
 cabalVerbosity (Verbosity 2) = "-v1"
 cabalVerbosity (Verbosity 3) = "-v2"
 cabalVerbosity (Verbosity _) = "-v3"
+ghcVerbosity    = cabalVerbosity
+ghcPkgVerbosity = cabalVerbosity
+setupVerbosity  = cabalVerbosity
 
 --------------------------------------------------------------------------------
 -- Posix/Windows style differences.

--- a/src/BuildEnv/Script.hs
+++ b/src/BuildEnv/Script.hs
@@ -50,6 +50,8 @@ import Data.Monoid
   ( Ap(..) )
 import Data.String
   ( IsString(..) )
+import System.IO
+  ( hFlush, stdout )
 
 -- directory
 import System.Directory
@@ -116,7 +118,7 @@ data BuildStep
   = CallProcess CallProcess
   -- | Create the given directory.
   | CreateDir   FilePath
-  -- | Log a message.
+  -- | Log a message to @stdout@.
   | LogMessage  String
   -- | Report one unit of progress.
   | ReportProgress
@@ -252,7 +254,7 @@ executeBuildStep :: Maybe Counter
 executeBuildStep mbCounter = \case
   CallProcess cp  -> callProcessInIO cp
   CreateDir   dir -> createDirectoryIfMissing True dir
-  LogMessage  msg -> putStrLn msg
+  LogMessage  msg -> do { putStrLn msg ; hFlush stdout }
   ReportProgress  -> for_ mbCounter \ counter -> do
     completed <-
       atomicModifyIORef' ( counterRef counter )


### PR DESCRIPTION
This adds progress indicators, both when executing the scripts in `IO` and when outputting build scripts.

I'm not sure whether there's something I should do about flushing to avoid logging output getting interleaved to an unreadable extent when compiling asychronously. This seems to be a much worse issue on Windows.