### PR TITLE
Allow resuming a build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,17 @@ jobs:
     - name: "Build executable"
       run: cabal build exe:build-env
 
+    - name: "Build 'c2hs' executable (command line), and restart a build"
+      working-directory: ./tests/ExeDeps
+      run: |
+        cabal run exe:build-env -- build exe:c2hs -f sources -o install -v2 --output-plan c2hs-plan.json
+        rm -rf install/alex*
+        rm -rf install/c2hs*
+        ghc-pkg unregister dlist --package-db sources/package.conf
+        ghc-pkg unregister dlist --package-db install/package.conf
+        cabal run exe:build-env -- build --plan c2hs-plan.json -f sources -o install -v2 --prefetched --resume
+        ghc-pkg --package-db=install/package.conf field dlist id
+
     - name: "Refine a build"
       working-directory: ./tests/Refine
       run: |
@@ -49,7 +60,7 @@ jobs:
       run: |
         mkdir -p localpkgs
         ( cd localpkgs ; cabal get distributive-0.6.2.1 )
-        cabal run exe:build-env -- build free --local distributive=localpkgs/distributive-0.6.2.1 -f sources --script build_free.sh --variables -v2
+        cabal run exe:build-env -- build free --local distributive=localpkgs/distributive-0.6.2.1 -f sources -o install --script build_free.sh --variables -v2
         mkdir -p build
         cp build_free.sh build/build_free.sh
         cp -a sources   build/srcs
@@ -77,11 +88,6 @@ jobs:
       run: |
         cabal run exe:build-env -- build --seeds seeds --freeze cabal.config -f sources -o install --haddock -j8 -v2
         ghc-pkg --package-db=install/package.conf field lens id
-
-    - name: "Build 'c2hs' executable (command line)"
-      working-directory: ./tests/ExeDeps
-      run: |
-        cabal run exe:build-env -- build exe:c2hs -f sources -o install -v2
 
     - name: "Generate a build script for 'attoparsec' and run it"
       working-directory: ./tests/Script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         rm -rf install/c2hs*
         ghc-pkg unregister dlist --package-db sources/package.conf
         ghc-pkg unregister dlist --package-db install/package.conf
-        cabal run exe:build-env -- build --plan c2hs-plan.json -f sources -o install -v2 --prefetched --resume
+        cabal run exe:build-env -- build --plan c2hs-plan.json -f sources -o install -v2 --resume
         ghc-pkg --package-db=install/package.conf field dlist id
 
     - name: "Refine a build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,11 @@ jobs:
 
     - name: "Build 'c2hs' executable (command line), and restart a build"
       working-directory: ./tests/ExeDeps
+      shell: bash
       run: |
         cabal run exe:build-env -- build exe:c2hs -f sources -o install -v2 --output-plan c2hs-plan.json
-        rm -rf install/alex*
-        rm -rf install/c2hs*
+        rm -rf install/bin/alex*
+        rm -rf install/bin/c2hs*
         ghc-pkg unregister dlist --package-db sources/package.conf
         ghc-pkg unregister dlist --package-db install/package.conf
         cabal run exe:build-env -- build --plan c2hs-plan.json -f sources -o install -v2 --resume
@@ -44,19 +45,22 @@ jobs:
 
     - name: "Refine a build"
       working-directory: ./tests/Refine
+      shell: bash
       run: |
         cabal run exe:build-env -- build shake -f sources -o install -v2 --only random
         ghc-pkg --package-db=install/package.conf field random id
 
     - name: "Build 'haskell-src-exts' (test build-tool-depends datadir)"
       working-directory: ./tests/ExeDataDir
+      shell: bash
       run: |
         cabal run exe:build-env -- build haskell-src-exts -f sources -o install -v2
         ghc-pkg --package-db=install/package.conf field haskell-src-exts id
 
     - name: "Relocate and run a build script for 'free' (with local 'distributive')"
-      working-directory: ./tests/RelocatableScript
       if: runner.os != 'Windows'
+      working-directory: ./tests/RelocatableScript
+      shell: bash
       run: |
         mkdir -p localpkgs
         ( cd localpkgs ; cabal get distributive-0.6.2.1 )
@@ -77,6 +81,7 @@ jobs:
 
     - name: "Plan, fetch and build 'comonad' (command line)"
       working-directory: ./tests/PlanFetchBuild
+      shell: bash
       run: |
         cabal run exe:build-env -- plan comonad -p plan.json -v2
         cabal run exe:build-env -- fetch -p plan.json -f sources -v2
@@ -85,13 +90,15 @@ jobs:
 
     - name: "Build 'lens' (seed file & cabal.config)"
       working-directory: ./tests/SEEDS
+      shell: bash
       run: |
         cabal run exe:build-env -- build --seeds seeds --freeze cabal.config -f sources -o install --haddock -j8 -v2
         ghc-pkg --package-db=install/package.conf field lens id
 
     - name: "Generate a build script for 'attoparsec' and run it"
-      working-directory: ./tests/Script
       if: runner.os != 'Windows'
+      working-directory: ./tests/Script
+      shell: bash
       run: |
         cabal run exe:build-env -- build attoparsec -f sources -o install --script build_atto.sh -v2
         chmod +x build_atto.sh
@@ -100,10 +107,12 @@ jobs:
 
     - name: "Test building packages with multiple public libraries"
       working-directory: ./tests/MultipleLibs
+      shell: bash
       run: |
         cabal run exe:build-env -- build pkg2:exe:Test -f fetch -o install --local pkg1=pkg1 --local pkg2=pkg2 -j8
 
     - name: "Bootstrap 'build-env'"
       working-directory: ./tests/Bootstrap
+      shell: bash
       run: |
         cabal run exe:build-env -- build build-env:exe:build-env -f fetch -o install --local build-env=../.. -j8

--- a/app/BuildEnv/Options.hs
+++ b/app/BuildEnv/Options.hs
@@ -139,6 +139,8 @@ data Build
     , mbOnlyDepsOf    :: Maybe ( Set PkgName )
       -- ^ @Just pkgs@ <=> only build @pkgs@ (and their dependencies).
       --   @Nothing@ <=> build all units in the build plan.
+    , resumeBuild     :: Bool
+      -- ^ Whether to resume a previous build, or start from scratch again.
     , userUnitArgs    :: ConfiguredUnit -> UnitArgs
       -- ^ Extra per-unit arguments.
     }

--- a/app/BuildEnv/Options.hs
+++ b/app/BuildEnv/Options.hs
@@ -102,13 +102,15 @@ data Plan
     { planJSONPath :: FilePath }
   deriving stock Show
 
--- | Whether to fetch the sources or to use prefetched sources.
-data Fetch
-  -- | Fetch the sources.
+-- | At which point to start/continue a build.
+data BuildStart
+  -- | Fetch sources and start a new build.
   = Fetch NewOrExisting
-  -- | The sources have already been fetched.
+  -- | Start a new build from prefetched sources.
   | Prefetched
-  deriving stock ( Show, Eq )
+  -- | Resume a previous build.
+  | Resume
+  deriving stock ( Show, Eq, Ord )
 
 -- | Whether to create a new directory or use an existing directory.
 data NewOrExisting
@@ -116,7 +118,7 @@ data NewOrExisting
   = New
   -- | Update an existing directory.
   | Existing
-  deriving stock ( Show, Eq )
+  deriving stock ( Show, Eq, Ord )
 
 -- | Information needed to perform a build.
 data Build
@@ -126,9 +128,8 @@ data Build
       --
       --  - fetched sources directory,
       --  - build output directory structure
-    , buildFetch      :: Fetch
-      -- ^ How to obtain the fetched sources,
-      -- including the build plan.
+    , buildStart      :: BuildStart
+      -- ^ At which stage should the build start?
     , buildBuildPlan  :: Plan
       -- ^ The build plan to follow.
     , buildStrategy   :: BuildStrategy
@@ -136,8 +137,6 @@ data Build
     , mbOnlyDepsOf    :: Maybe ( Set PkgName )
       -- ^ @Just pkgs@ <=> only build @pkgs@ (and their dependencies).
       --   @Nothing@ <=> build all units in the build plan.
-    , resumeBuild     :: Bool
-      -- ^ Whether to resume a previous build, or start from scratch again.
     , userUnitArgs    :: ConfiguredUnit -> UnitArgs
       -- ^ Extra per-unit arguments.
     }

--- a/app/BuildEnv/Options.hs
+++ b/app/BuildEnv/Options.hs
@@ -126,9 +126,6 @@ data Build
       --
       --  - fetched sources directory,
       --  - build output directory structure
-      --
-      -- NB: the build directories are ignored if we are ouputting
-      -- a shell script containing variables.
     , buildFetch      :: Fetch
       -- ^ How to obtain the fetched sources,
       -- including the build plan.

--- a/app/BuildEnv/Parse.hs
+++ b/app/BuildEnv/Parse.hs
@@ -43,6 +43,8 @@ import qualified Data.Text as Text
 import BuildEnv.CabalPlan
 import BuildEnv.Config
 import BuildEnv.Options
+import BuildEnv.Utils
+  ( splitOn )
 
 --------------------------------------------------------------------------------
 
@@ -242,15 +244,6 @@ allowNewer =
       | otherwise
       = Nothing
 
--- | Utility list 'splitOn' function.
-splitOn :: Char -> String -> [String]
-splitOn c = go
-  where
-    go "" = []
-    go s
-      | (a,as) <- break (== c) s
-      = a : go (drop 1 as)
-
 -- | Parse a collection of seed dependencies, either from a seed file
 -- or from explicit command-line arguments.
 dependencies :: ModeDescription -> Parser ( PackageData UnitSpecs )
@@ -369,6 +362,7 @@ build = do
   getBuildStrat      <- optStrategy
   mbBuildPaths       <- optMbBuildPaths
   userUnitArgs       <- optUnitArgs
+  resumeBuild        <- optResumeBuild
   mbOnlyDepsOf       <- optOnlyDepsOf
 
   pure $
@@ -387,6 +381,7 @@ build = do
                   , buildStrategy
                   , buildRawPaths
                   , userUnitArgs
+                  , resumeBuild
                   , mbOnlyDepsOf }
 
   where
@@ -492,6 +487,12 @@ build = do
                    <> help "Pass argument to 'ghc-pkg register'"
                    <> metavar "ARG" )
       pure $ const args
+
+    optResumeBuild :: Parser Bool
+    optResumeBuild =
+      switch
+        (  long "resume"
+        <> help "Resume a partially-completed build" )
 
     optOnlyDepsOf :: Parser ( Maybe ( Set PkgName ) )
     optOnlyDepsOf = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -58,6 +58,7 @@ main = do
       BuildMode ( Build { buildBuildPlan
                         , buildFetch, buildStrategy
                         , buildRawPaths = rawPaths
+                        , resumeBuild
                         , mbOnlyDepsOf
                         , userUnitArgs } ) -> do
         plan <- getPlan delTemp verbosity workDir compiler cabal buildBuildPlan
@@ -79,7 +80,7 @@ main = do
                   in Just $ mapMaybePlanUnits wantUnit plan
 
         buildPlan verbosity workDir pathsForPrep pathsForBuild
-          buildStrategy mbOnlyDepsOfUnits userUnitArgs plan
+          buildStrategy resumeBuild mbOnlyDepsOfUnits userUnitArgs plan
 
 -- | Generate the contents of @pkg.cabal@ and @cabal.project@ files, using
 --

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,10 @@ transitive dependencies thereof.
 Note that `--only` only affects which packages are built; it does not change
 the computation of the build plan nor which packages are fetched.
 
+You can also resume a build where it left off by passing `--resume`; this will
+avoid rebuilding any of the units that have already been registed in the
+package database.
+
 ## Bootstrapping
 
 In the example from [§ Hermetic builds](#hermetic-builds), we ran

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ when running the `Setup` script:
 
   - `with-compiler`, `prefix` and `destdir` options supplied by the user,
   - the default `datadir` option,
-  - `cid`, `datasubdir` and `builddir` options supplied by `build-env`,
+  - `cid`, `datasubdir`, `bindir` and `builddir` options supplied by `build-env`,
   - package flags and `dependency` arguments, obtained from the build plan,
   - `<pkg>_datadir` environment variables supplied by `build-env`.
 

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -277,7 +277,7 @@ buildUnit verbosity
            , prog         = setupExe
            , args         = [ "build"
                             , "--builddir=" ++ buildDir
-                            , setupVerbosity verbosity]
+                            , setupVerbosity verbosity ]
            , extraPATH    = binDirs
            , extraEnvVars = depDataDirs
            , sem          = noSem

--- a/src/BuildEnv/Config.hs
+++ b/src/BuildEnv/Config.hs
@@ -185,9 +185,10 @@ data instance BuildPaths Raw
       -- ^ Raw output build @prefix@ (might be relative).
     }
 data instance BuildPaths ForPrep
-  = NoBuildPathsForPrep
-    -- ^ Placeholder to ensure that no build paths are used
-    -- during the build preparation stage.
+  = BuildPathsForPrep
+    { compilerForPrep :: !Compiler
+      -- ^ Which @ghc@ and @ghc-pkg@ to use
+    }
 data instance BuildPaths ForBuild
   = BuildPaths
     { compiler   :: !Compiler
@@ -257,7 +258,7 @@ canonicalizePaths compiler buildStrat
                            , buildPaths =
                              BuildPaths { compiler, destDir, prefix, installDir } }
       return $
-        ( Paths { fetchDir, buildPaths = NoBuildPathsForPrep }, forBuild )
+        ( Paths { fetchDir, buildPaths = BuildPathsForPrep { compilerForPrep = compiler } }, forBuild )
 
 -- | How to handle deletion of temporary directories.
 data TempDirPermanence

--- a/src/BuildEnv/Script.hs
+++ b/src/BuildEnv/Script.hs
@@ -260,7 +260,8 @@ executeBuildStep mbCounter = \case
           [ ""
           , " " <> replicate n '#'
           , " " <> txt
-          , " " <> replicate n '#' ]
+          , " " <> replicate n '#'
+          , "" ]
 
 ----------------
 -- Shell script

--- a/src/BuildEnv/Utils.hs
+++ b/src/BuildEnv/Utils.hs
@@ -24,6 +24,9 @@ module BuildEnv.Utils
     , AbstractSem(..)
     , newAbstractSem, noSem, abstractQSem
 
+      -- * Other utilities
+    , splitOn
+
     ) where
 
 -- base
@@ -180,6 +183,15 @@ withTempDir del name k =
     Don'tDeleteTempDirs
       -> do root <- getCanonicalTemporaryDirectory
             createTempDirectory root name >>= k
+
+-- | Utility list 'splitOn' function.
+splitOn :: Char -> String -> [String]
+splitOn c = go
+  where
+    go "" = []
+    go s
+      | (a,as) <- break (== c) s
+      = a : go (drop 1 as)
 
 --------------------------------------------------------------------------------
 -- Semaphores.


### PR DESCRIPTION
This addresses #14, allowing a build to be resumed.

I haven't tested this at all yet. I need to add a test, but I'm not sure how to do so... how should the build be interrupted in the first place?

Thinking about a situation in which a build has failed, one might know which package failed. If one wants to fix that and resume as before, that's fine. But perhaps one wants to remove some packages from the build plan and continue. Currently we support `--only` to say "only build these packages and their dependencies", but if it isn't clear which packages remain to build it's not necessarily obvious how to proceed. For example, if one has just built 500 packages and suddenly want to exclude... `wingman`... from the build plan.

This also doesn't handle executables. I'm not sure how to figure out the `UnitId`s.