### PR TITLE
Clean up configure args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist-newstyle/
 cabal.project.local
+logs/
 *.json
 *.sh

--- a/build-env.cabal
+++ b/build-env.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          build-env
-version:       1.0.0.0
+version:       1.1.0.0
 author:        Ben Gamari & Sam Derbyshire
 maintainer:    ben@smart-cactus.org
 license:       BSD-3-Clause
@@ -21,12 +21,7 @@ description:
   package database.
 
   In particular, __build-env__ enables bootstrapping of Haskell packages
-  in hermetic build environments without the use of @cabal-install@ or Stack.
-
-  It can be used as a library, or as an executable.
-
-  Please refer to the [readme](https://github.com/bgamari/build-env/readme.md)
-  for more information and usage examples.
+  in hermetic build environments, without the use of @cabal-install@ or Stack.
 
 common common
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,17 @@
 # Changelog for `build-env`
 
-## Version 1.0.0.0 (2022-12-XX)
+## Version 1.1.0.0 (2023-03-09)
 
-- First Hackage release.
+- Change the default directory structure produced by `build-env` to be more
+  predictable.
+
+- Ensure that important arguments to Cabal configure override arguments
+  passed using `--configure-arg=`, as they are essential for `build-env`
+  to function.
+
+## Version 1.0.0.0 (2022-12-26)
+
+- First released version.
 
 ## Version 0.1.0.0 (2022-11-16)
 

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -347,7 +347,7 @@ cabalFetch verbosity cabal root pkgNmVer = do
 
 -- | Build a 'CabalPlan'. This will install all the packages in the plan
 -- by running their @Setup@ scripts. Libraries will be registered
--- into a local package database at @<install-dir>/package.conf@.
+-- into a local package database at @installDir/package.conf@.
 buildPlan :: Verbosity
           -> FilePath
               -- ^ Working directory.


### PR DESCRIPTION
This is a small refactoring that ensures the user doesn't override important arguments to `Setup configure` with `--configure-arg`, and also improves some of the defaults to make the directory structure more predictable and less cluttered.