### PR TITLE
[build-env] Allow specifying an index-state for the project

### DIFF
--- a/app/BuildEnv/Options.hs
+++ b/app/BuildEnv/Options.hs
@@ -8,6 +8,8 @@
 -- expected by the command-line interface of @build-env@.
 module BuildEnv.Options where
 
+import Data.Text (Text)
+
 -- containers
 import Data.Set
   ( Set )
@@ -73,6 +75,8 @@ data PlanInputs
       -- ^ Additional package constraints.
     , planAllowNewer :: AllowNewer
       -- ^ Allow-newer specification.
+    , planIndexState :: Maybe Text
+      -- ^ index-state specification.
     }
   deriving stock Show
 

--- a/app/BuildEnv/Parse.hs
+++ b/app/BuildEnv/Parse.hs
@@ -184,8 +184,9 @@ planInputs modeDesc = do
   planPins <- optional (freeze modeDesc)
   planUnits <- dependencies modeDesc
   planAllowNewer <- allowNewer
+  planIndexState <- indexState
 
-  pure $ PlanInputs { planPins, planUnits, planAllowNewer }
+  pure $ PlanInputs { planPins, planUnits, planAllowNewer, planIndexState }
 
 -- | Parse a list of pinned packages from a 'cabal.config' freeze file.
 freeze :: ModeDescription -> Parser ( PackageData PkgSpecs )
@@ -196,6 +197,13 @@ freeze modeDesc = FromFile <$> freezeFile
 
     helpStr :: String
     helpStr = modeDescription modeDesc <> " 'cabal.config' freeze file"
+
+indexState :: Parser (Maybe Text)
+indexState =
+  optional $ fmap Text.pack $
+    option str ( long "index-state" <> help helpStr <> metavar "DATE" )
+  where
+    helpStr = "use Hackage state as of DATE, e.g. 2022-12-25T00:00:00Z"
 
 -- | Parse @allow-newer@ options.
 allowNewer :: Parser AllowNewer

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -173,12 +173,19 @@ computePlan delTemp verbosity comp cabal ( CabalFilesContents { cabalContents, p
 
 -- | The contents of a dummy @cabal.project@ file, specifying
 -- package constraints, flags and allow-newer.
-cabalProjectContentsFromPackages :: FilePath -> UnitSpecs -> PkgSpecs -> AllowNewer -> Text
-cabalProjectContentsFromPackages workDir units pins (AllowNewer allowNewer) =
+cabalProjectContentsFromPackages
+  :: FilePath
+  -> UnitSpecs
+  -> PkgSpecs
+  -> AllowNewer
+  -> Maybe Text
+  -> Text
+cabalProjectContentsFromPackages workDir units pins (AllowNewer allowNewer) indexState =
       packages
    <> allowNewers
    <> flagSpecs
    <> constraints
+   <> indexStateDecl
   where
 
     packages
@@ -232,6 +239,10 @@ cabalProjectContentsFromPackages workDir units pins (AllowNewer allowNewer) =
         , let flags = psFlags ps
         , not $ flagSpecIsEmpty flags
         ]
+
+    indexStateDecl
+      | Just date <- indexState = Text.unlines [ "index-state: " <> date ]
+      | otherwise = ""
 
 -- | The contents of a dummy Cabal file with dependencies on
 -- the specified units (without any constraints).


### PR DESCRIPTION
This is useful for making the build plan reproducible in the future.