### PR TITLE
Make builds relocatable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,20 @@ jobs:
           cabal run exe:build-env -- build exe:c2hs -f sources -o install -v2 --output-plan c2hs-plan.json
           rm -rf install/bin/alex*
           rm -rf install/bin/c2hs*
-          ghc-pkg unregister dlist --package-db sources/package.conf
           ghc-pkg unregister dlist --package-db install/package.conf
           cabal run exe:build-env -- build --plan c2hs-plan.json -f sources -o install -v2 --resume
           ghc-pkg --package-db=install/package.conf field dlist id
+
+      - name: "Build 'c2hs' with --enable-relocatable and run Alex"
+        if: runner.os != 'Windows' && runner.os != 'macOS'
+        working-directory: ./tests/Reloc
+        shell: bash
+        run: |
+          cabal run exe:build-env -- build exe:c2hs -f sources -o install -v2 --configure-arg --enable-relocatable
+          grep -r -zE "${pkgroot}/lib/language-c" install/package.conf
+          cp -r install other
+          $(find "other/bin" -type f -name "alex") test.x
+        # Run Alex as a smoke-test to check that data directories are set correctly.
 
       - name: "Refine a build"
         working-directory: ./tests/Refine

--- a/src/BuildEnv/Build.hs
+++ b/src/BuildEnv/Build.hs
@@ -402,7 +402,7 @@ buildPlan verbosity workDir
           userUnitArgs
           cabalPlan
   = do
-    let paths@( BuildPaths { compiler, prefix, destDir, installDir } )
+    let paths@( BuildPaths { compiler, prefix, installDir } )
           = buildPaths pathsForBuild
 
         pkgDbDirsForPrep@( PkgDbDirsForPrep { tempPkgDbDir = prepTempPkgDbDir } )
@@ -430,7 +430,6 @@ buildPlan verbosity workDir
     verboseMsg verbosity $
       Text.unlines [ "Directory structure:"
                    , "      prefix: " <> Text.pack prefix
-                   , "     destDir: " <> Text.pack destDir
                    , "  installDir: " <> Text.pack installDir ]
 
     mbAlreadyBuilt <-

--- a/src/BuildEnv/Config.hs
+++ b/src/BuildEnv/Config.hs
@@ -227,8 +227,6 @@ data instance BuildPaths ForBuild
   = BuildPaths
     { compiler   :: !Compiler
       -- ^ Which @ghc@ and @ghc-pkg@ to use.
-    , destDir    :: !FilePath
-      -- ^ Output build @destdir@ (absolute).
     , prefix     :: !FilePath
       -- ^ Output build @prefix@ (absolute).
     , installDir :: !FilePath
@@ -264,7 +262,6 @@ canonicalizePaths compiler buildStrat
   = do
       fetchDir   <- canonicalizePath fetchDir0
       prefix     <- canonicalizePath rawPrefix
-      destDir    <- canonicalizePath rawDestDir
       installDir <- canonicalizePath ( rawDestDir </> dropDrive prefix )
         -- We must use dropDrive here. Quoting from the documentation of (</>):
         --
@@ -288,7 +285,6 @@ canonicalizePaths compiler buildStrat
                        , buildPaths =
                          BuildPaths
                            { prefix     = "${PREFIX}"
-                           , destDir    = "${DESTDIR}"
                            , installDir = "${DESTDIR}" </> "${PREFIX}"
                            , logDir
                            , compiler =
@@ -297,7 +293,7 @@ canonicalizePaths compiler buildStrat
             _don'tUseVars ->
               Paths { fetchDir
                     , buildPaths =
-                      BuildPaths { compiler, destDir, prefix, installDir, logDir } }
+                      BuildPaths { compiler, prefix, installDir, logDir } }
       return $
         ( Paths { fetchDir
                 , buildPaths =

--- a/src/BuildEnv/Script.hs
+++ b/src/BuildEnv/Script.hs
@@ -215,7 +215,7 @@ data EscapeVars
 
 -- | Quote a string, to avoid spaces causing the string
 -- to be interpreted as multiple arguments.
-q :: ( IsString r, Monoid r ) => EscapeVars-> String -> r
+q :: ( IsString r, Monoid r ) => EscapeVars -> String -> r
 q escapeVars t = "\"" <> fromString ( escapeArg t ) <> "\""
   where
     escapeArg :: String -> String

--- a/tests/Reloc/.gitignore
+++ b/tests/Reloc/.gitignore
@@ -1,0 +1,4 @@
+sources/
+install/
+logs/
+*.json

--- a/tests/Reloc/test.x
+++ b/tests/Reloc/test.x
@@ -1,0 +1,38 @@
+{
+module Main where
+}
+
+%wrapper "basic"
+
+$digit = 0-9			-- digits
+$alpha = [a-zA-Z]		-- alphabetic characters
+
+tokens :-
+
+  $white+				{ \s -> White }
+  "--".*				{ \s -> Comment }
+  let					{ \s -> Let }
+  in					{ \s -> In }
+  $digit+				{ \s -> Int (read s) }
+  [\=\+\-\*\/\(\)]			{ \s -> Sym (head s) }
+  $alpha [$alpha $digit \_ \']*		{ \s -> Var s }
+
+{
+-- Each right-hand side has type :: String -> Token
+
+-- The token type:
+data Token =
+        White		|
+        Comment		|
+	Let 		|
+	In  		|
+	Sym Char	|
+	Var String	|
+	Int Int		|
+	Err 
+	deriving (Eq,Show)
+
+main = do
+  s <- getContents
+  print (alexScanTokens s)
+}


### PR DESCRIPTION
This MR allows `--enable-relocatable` to be used to produce relocatable package databases. A new test is added which uses `--enable-relocatable` and then checks that we can relocate and run `alex` without setting the `alex_datadir` environment variable.