### PR TITLE
Improve support of working-directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
-# Trigger the workflow on push or pull request, but only for the main branch
+# Trigger the workflow on push or pull request, but only for the master branch
 on:
-  pull_request:
   push:
-    branches: [master]
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   cabal:
@@ -84,6 +87,23 @@ jobs:
           cp -r install other
           $(find "other/bin" -type f -name "alex") test.x
         # Run Alex as a smoke-test to check that data directories are set correctly.
+
+      - name: "Test working directory (direct)"
+        working-directory: ./tests/WorkDirDirect
+        shell: bash
+        run: |
+          cabal run exe:build-env -- --cwd wd build hashable -f sources -o install
+          ghc-pkg --package-db=wd/install/package.conf field hashable id
+
+      - name: "Test working directory (script)"
+        if: runner.os != 'Windows'
+        working-directory: ./tests/WorkDirScript
+        shell: bash
+        run: |
+          cabal run exe:build-env -- --cwd wd build hashable -f sources -o install --script build_hash.sh -v2
+          chmod +x build_hash.sh
+          ./build_hash.sh
+          ghc-pkg --package-db=wd/install/package.conf field hashable id
 
       - name: "Refine a build"
         working-directory: ./tests/Refine

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 module Main ( main ) where
 
 -- base
@@ -34,59 +36,59 @@ import BuildEnv.File
 import BuildEnv.Options
 import BuildEnv.Parse
   ( runOptionsParser )
+import BuildEnv.Path
 
 --------------------------------------------------------------------------------
 
 main :: IO ()
 main = do
-  currentDir <- getCurrentDirectory
-  Opts { compiler, cabal
-       , mode, verbosity, delTemp, workDir
-       , indexState = mbIndexState }
-    <- runOptionsParser currentDir
+  ( GlobalOpts
+      { compiler, cabal
+      , verbosity, delTemp, workDir
+      , indexState = mbIndexState }
+    , mode )
+    <- runOptionsParser
   hSetBuffering stdout $ BlockBuffering Nothing
-  withCurrentDirectory workDir $
-    case mode of
-      PlanMode { planModeInputs, planOutput } -> do
-        CabalPlanBinary planBinary <-
-          computePlanFromInputs
-            delTemp verbosity workDir compiler cabal
-            mbIndexState planModeInputs
-        normalMsg verbosity $
-          "Writing build plan to '" <> Text.pack planOutput <> "'"
-        Lazy.ByteString.writeFile planOutput planBinary
-      FetchMode ( FetchDescription { rawFetchDir, fetchInputPlan } ) newOrUpd -> do
-        plan <- getPlan delTemp verbosity workDir compiler cabal mbIndexState fetchInputPlan
-        fetchDir <- canonicalizePath rawFetchDir
-        doFetch verbosity cabal mbIndexState fetchDir True newOrUpd plan
-      BuildMode ( Build { buildBuildPlan
-                        , buildStart
-                        , buildStrategy
-                        , buildRawPaths = rawPaths
-                        , mbOnlyDepsOf
-                        , eventLogDir
-                        , userUnitArgs } ) -> do
-        plan <- getPlan delTemp verbosity workDir compiler cabal mbIndexState buildBuildPlan
-        ( pathsForPrep@( Paths { fetchDir }), pathsForBuild )
-          <- canonicalizePaths compiler buildStrategy rawPaths
-        case buildStart of
-          Fetch newOrUpd -> doFetch verbosity cabal mbIndexState fetchDir False newOrUpd plan
-          _              -> return ()
-        let mbOnlyDepsOfUnits :: Maybe [UnitId]
-            mbOnlyDepsOfUnits =
-              case mbOnlyDepsOf of
-                Nothing -> Nothing
-                Just pkgs ->
-                  let wantUnit :: PlanUnit -> Maybe UnitId
-                      wantUnit pu = do
-                        ConfiguredUnit { puPkgName, puId } <- configuredUnitMaybe pu
-                        guard ( puPkgName `Set.member` pkgs )
-                        return puId
-                  in Just $ mapMaybePlanUnits wantUnit plan
+  case mode of
+    PlanMode { planModeInputs, planOutput } -> do
+      CabalPlanBinary planBinary <-
+        computePlanFromInputs
+          delTemp verbosity workDir compiler cabal
+          mbIndexState planModeInputs
+      normalMsg verbosity $
+        "Writing build plan to" <> Text.pack ( show planOutput )
+      Lazy.ByteString.writeFile ( interpretSymbolicPath workDir planOutput ) planBinary
+    FetchMode ( FetchDescription { fetchDir, fetchInputPlan } ) newOrUpd -> do
+      plan <- getPlan delTemp verbosity workDir compiler cabal mbIndexState fetchInputPlan
+      doFetch verbosity cabal workDir fetchDir mbIndexState True newOrUpd plan
+    BuildMode ( Build { buildBuildPlan
+                      , buildStart
+                      , buildStrategy
+                      , buildRawPaths = rawPaths
+                      , mbOnlyDepsOf
+                      , eventLogDir
+                      , userUnitArgs } ) -> do
+      plan <- getPlan delTemp verbosity workDir compiler cabal mbIndexState buildBuildPlan
+      ( pathsForPrep@( Paths { fetchDir }), pathsForBuild )
+        <- canonicalizePaths compiler buildStrategy workDir rawPaths
+      case buildStart of
+        Fetch newOrUpd -> doFetch verbosity cabal workDir fetchDir mbIndexState False newOrUpd plan
+        _              -> return ()
+      let mbOnlyDepsOfUnits :: Maybe [UnitId]
+          mbOnlyDepsOfUnits =
+            case mbOnlyDepsOf of
+              Nothing -> Nothing
+              Just pkgs ->
+                let wantUnit :: PlanUnit -> Maybe UnitId
+                    wantUnit pu = do
+                      ConfiguredUnit { puPkgName, puId } <- configuredUnitMaybe pu
+                      guard ( puPkgName `Set.member` pkgs )
+                      return puId
+                in Just $ mapMaybePlanUnits wantUnit plan
 
-        let resumeBuild = case buildStart of { Resume -> True; _ -> False }
-        buildPlan verbosity workDir pathsForPrep pathsForBuild eventLogDir
-          buildStrategy resumeBuild mbOnlyDepsOfUnits userUnitArgs plan
+      let resumeBuild = case buildStart of { Resume -> True; _ -> False }
+      buildPlan verbosity workDir pathsForPrep pathsForBuild eventLogDir
+        buildStrategy resumeBuild mbOnlyDepsOfUnits userUnitArgs plan
 
 -- | Generate the contents of @pkg.cabal@ and @cabal.project@ files, using
 --
@@ -94,100 +96,107 @@ main = do
 --    and allow-newer),
 --  - a @cabal.config@ freeze file,
 --  - explicit packages and allow-newer specified as command-line arguments.
-parsePlanInputs :: Verbosity -> FilePath -> Maybe IndexState -> PlanInputs -> IO CabalFilesContents
+parsePlanInputs :: Verbosity
+                -> SymbolicPath CWD ( Dir Project )
+                -> Maybe IndexState -> PlanInputs -> IO CabalFilesContents
 parsePlanInputs verbosity workDir mbIndexState
   ( PlanInputs { planPins, planUnits, planAllowNewer } )
-  = do (pkgs, fileAllowNewer) <- parsePlanUnits verbosity planUnits
-       let
-         allAllowNewer = fileAllowNewer <> planAllowNewer
-           -- NB: allow-newer specified in the command-line overrides
-           -- the allow-newer included in the seed file.
-         cabalContents = cabalFileContentsFromPackages pkgs
-       projectContents <-
-         case planPins of
-           Nothing -> return $ cabalProjectContentsFromPackages workDir pkgs Map.empty
-             allAllowNewer mbIndexState
-           Just (FromFile pinCabalConfig) -> do
-             normalMsg verbosity $
-               "Reading 'cabal.config' file at '" <> Text.pack pinCabalConfig <> "'"
-             pins <- parseCabalDotConfigPkgs pinCabalConfig
-             return $ cabalProjectContentsFromPackages workDir pkgs pins
-               allAllowNewer mbIndexState
-           Just (Explicit pins) -> do
-             return $ cabalProjectContentsFromPackages workDir pkgs pins
-               allAllowNewer mbIndexState
-       return $ CabalFilesContents { cabalContents, projectContents }
+  = do
+      ( pkgs, fileAllowNewer ) <- parsePlanUnits verbosity workDir planUnits
+      let
+        allAllowNewer = fileAllowNewer <> planAllowNewer
+          -- NB: allow-newer specified in the command-line overrides
+          -- the allow-newer included in the seed file.
+        cabalContents = cabalFileContentsFromPackages pkgs
+      pins <-
+        case planPins of
+          Nothing -> return Map.empty
+          Just ( FromFile pinCabalConfig ) -> do
+            normalMsg verbosity $
+              "Reading 'cabal.config' file at " <> Text.pack ( show pinCabalConfig )
+            pins <- parseCabalDotConfigPkgs ( interpretSymbolicPath workDir pinCabalConfig )
+            return pins
+          Just ( Explicit pins ) -> do
+            return pins
+      projectContents <-
+        cabalProjectContentsFromPackages workDir pkgs pins allAllowNewer mbIndexState
+      return $ CabalFilesContents { cabalContents, projectContents }
 
 -- | Retrieve the seed units we want to build, either from a seed file
 -- or from explicit command line arguments.
-parsePlanUnits :: Verbosity -> PackageData UnitSpecs -> IO (UnitSpecs, AllowNewer)
-parsePlanUnits _ ( Explicit units )      = return (units, AllowNewer Set.empty)
-parsePlanUnits verbosity ( FromFile fp ) =
-  do normalMsg verbosity $
-       "Reading seed packages from '" <> Text.pack fp <> "'"
-     parseSeedFile fp
+parsePlanUnits :: Verbosity
+               -> SymbolicPath CWD ( Dir Project )
+               -> PackageData UnitSpecs -> IO ( UnitSpecs, AllowNewer )
+parsePlanUnits _ _ ( Explicit units ) = return (units, AllowNewer Set.empty)
+parsePlanUnits verbosity workDir ( FromFile fp ) = do
+  normalMsg verbosity $
+    "Reading seed packages from " <> Text.pack ( show fp ) <> ""
+  parseSeedFile ( interpretSymbolicPath workDir fp )
 
 -- | Compute a build plan by calling @cabal build --dry-run@ with the generated
 -- @pkg.cabal@ and @cabal.project@ files.
 computePlanFromInputs :: TempDirPermanence
                       -> Verbosity
-                      -> FilePath
+                      -> SymbolicPath CWD ( Dir Project )
                       -> Compiler
                       -> Cabal
                       -> Maybe IndexState
                       -> PlanInputs
                       -> IO CabalPlanBinary
-computePlanFromInputs delTemp verbosity workDir comp cabal mbIndexState inputs
-  = do cabalFileContents <- parsePlanInputs verbosity workDir mbIndexState inputs
-       normalMsg verbosity "Computing build plan"
-       computePlan delTemp verbosity comp cabal cabalFileContents
+computePlanFromInputs delTemp verbosity workDir comp cabal mbIndexState inputs = do
+  cabalFileContents <- parsePlanInputs verbosity workDir mbIndexState inputs
+  normalMsg verbosity "Computing build plan"
+  computePlan delTemp verbosity comp cabal workDir cabalFileContents
 
 -- | Retrieve a cabal build plan, either by computing it or using
 -- a pre-existing @plan.json@ file.
-getPlan :: TempDirPermanence -> Verbosity -> FilePath -> Compiler -> Cabal -> Maybe IndexState -> Plan -> IO CabalPlan
+getPlan :: TempDirPermanence -> Verbosity
+        -> SymbolicPath CWD ( Dir Project )
+        -> Compiler -> Cabal -> Maybe IndexState -> Plan -> IO CabalPlan
 getPlan delTemp verbosity workDir comp cabal mbIndexState planMode = do
-   planBinary <-
-     case planMode of
-       ComputePlan planInputs mbPlanOutputPath -> do
-        plan@(CabalPlanBinary planData) <-
+  planBinary <-
+    case planMode of
+      ComputePlan planInputs mbPlanOutputPath -> do
+        plan@( CabalPlanBinary planData ) <-
           computePlanFromInputs delTemp verbosity workDir comp cabal mbIndexState planInputs
         for_ mbPlanOutputPath \ planOutputPath ->
-          Lazy.ByteString.writeFile planOutputPath planData
+          Lazy.ByteString.writeFile ( interpretSymbolicPath workDir planOutputPath ) planData
         return plan
-       UsePlan { planJSONPath } ->
-         do
-           normalMsg verbosity $
-             "Reading build plan from '" <> Text.pack planJSONPath <> "'"
-           CabalPlanBinary <$> Lazy.ByteString.readFile planJSONPath
-   return $ parsePlanBinary planBinary
+      UsePlan { planJSONPath } -> do
+        normalMsg verbosity $
+          "Reading build plan from " <> Text.pack ( show planJSONPath )
+        CabalPlanBinary <$> Lazy.ByteString.readFile ( interpretSymbolicPath workDir planJSONPath )
+  return $ parsePlanBinary planBinary
 
 -- | Fetch all packages in a cabal build plan.
 doFetch :: Verbosity
         -> Cabal
+        -> SymbolicPath CWD ( Dir Project )
+           -- ^ working directory
+        -> SymbolicPath Project ( Dir Fetch )
+           -- ^ fetch directory
         -> Maybe IndexState
-        -> FilePath
         -> Bool -- ^ True <=> we are fetching (not building)
                 -- (only relevant for error messages)
         -> NewOrExisting
         -> CabalPlan
         -> IO ()
-doFetch verbosity cabal mbIndexState fetchDir0 weAreFetching newOrUpd plan = do
-  fetchDir       <- canonicalizePath fetchDir0
-  fetchDirExists <- doesDirectoryExist fetchDir
+doFetch verbosity cabal workDir fetchDir mbIndexState weAreFetching newOrUpd plan = do
+  fetchDirExists <- doesDirectoryExist $ interpretSymbolicPath workDir fetchDir
   case newOrUpd of
     New | fetchDirExists ->
       error $ unlines $
        "Fetch directory already exists." : existsMsg
-          ++ [ "Fetch directory: " <> fetchDir  ]
+          ++ [ "Fetch directory: " <> show fetchDir ]
     Existing | not fetchDirExists ->
       error $ unlines
         [ "Fetch directory must already exist when using --update."
-        , "Fetch directory: " <> fetchDir ]
+        , "Fetch directory: " <> show fetchDir ]
     _ -> return ()
-  createDirectoryIfMissing True fetchDir
+  createDirectoryIfMissing True $ interpretSymbolicPath workDir fetchDir
   normalMsg verbosity $
-    "Fetching sources from build plan into directory '" <> Text.pack fetchDir <> "'"
-  fetchPlan verbosity cabal mbIndexState fetchDir plan
+    "Fetching sources from build plan into directory " <> Text.pack ( show fetchDir )
+  fetchPlan verbosity cabal workDir mbIndexState fetchDir plan
 
   where
     existsMsg

--- a/build-env.cabal
+++ b/build-env.cabal
@@ -82,6 +82,7 @@ library
       , BuildEnv.Config
       , BuildEnv.File
       , BuildEnv.Script
+      , BuildEnv.Path
       , BuildEnv.Utils
 
     build-depends:

--- a/src/BuildEnv/BuildOne.hs
+++ b/src/BuildEnv/BuildOne.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -46,12 +47,6 @@ import qualified Data.Map.Strict as Map
 -- directory
 import System.Directory
 
--- filepath
-import System.FilePath
-  ( (</>), (<.>)
-  , makeRelative
-  )
-
 -- text
 import Data.Text
   ( Text )
@@ -62,6 +57,7 @@ import qualified Data.Text as Text
 import BuildEnv.Config
 import BuildEnv.CabalPlan
 import BuildEnv.Script
+import BuildEnv.Path
 import BuildEnv.Utils
   ( ProgPath(..), CallProcess(..)
   , abstractQSem, noSem
@@ -75,6 +71,7 @@ import BuildEnv.Utils
 -- Returns a build script which compiles the @Setup@ script.
 setupPackage :: Verbosity
              -> Compiler
+             -> SymbolicPath CWD ( Dir Project )
              -> BuildPaths ForBuild -- ^ Overall build directory structure.
              -> PkgDbDir   ForBuild -- ^ Package database directory (see 'getPkgDbDirForBuild').
              -> PkgDir     ForPrep  -- ^ Package directory (to find the @Setup.hs@).
@@ -84,6 +81,7 @@ setupPackage :: Verbosity
              -> IO BuildScript
 setupPackage verbosity
              ( Compiler { ghcPath } )
+             workDir
              paths@( BuildPaths { installDir, logDir } )
              ( PkgDbDirForBuild { finalPkgDbDir } )
              ( PkgDir { pkgNameVer, pkgDir = prepPkgDir } )
@@ -91,23 +89,24 @@ setupPackage verbosity
              plan
              unit@( ConfiguredUnit { puId, puSetupDepends, puExeDepends } )
 
-  = do let logPath
+  = do let logPath :: Maybe ( AbsolutePath File )
+           logPath
              | verbosity <= Quiet
              = Nothing
              | otherwise
-             = Just $ logDir </> Text.unpack ( unUnitId puId )
+             = Just $ logDir </> mkRelativePath ( Text.unpack ( unUnitId puId ) )
        -- Find the appropriate Setup.hs file (creating one if necessary)
-       setupHs <- findSetupHs prepPkgDir
+       setupHs <- findSetupHs workDir prepPkgDir
        return do
          scriptCfg <- askScriptConfig
          let isCabalDep uid = case Map.lookup uid plan of
                Nothing -> error $ "setupPackage: cannot find setup dependency " ++ show uid
                Just pu -> planUnitPkgName pu == PkgName "Cabal"
              extraCabalSetupDep = not $ any isCabalDep puSetupDepends
-             setupArgs = [ quoteArg ExpandVars scriptCfg ( buildPkgDir </> setupHs )
+             setupArgs = [ quoteArg ExpandVars scriptCfg ( getSymbolicPath $ setupHs )
                          , "-o"
-                         , quoteArg ExpandVars scriptCfg ( buildPkgDir </> "Setup" )
-                         , "-package-db=" <> quoteArg ExpandVars scriptCfg finalPkgDbDir
+                         , quoteArg ExpandVars scriptCfg ( getSymbolicPath $ mkRelativePath "Setup" )
+                         , "-package-db=" <> quoteArg ExpandVars scriptCfg ( getAbsolutePath finalPkgDbDir )
                          , ghcVerbosity verbosity
                          ] ++ map unitIdArg puSetupDepends
                            ++ [ "-package Cabal" | extraCabalSetupDep ]
@@ -117,7 +116,7 @@ setupPackage verbosity
              -- Specify location of binaries and data directories.
              --
              -- See the commentary around 'depDataDirs' in 'buildUnit'.
-             binDirs = [ quoteArg ExpandVars scriptCfg $ installDir </> "bin" </> Text.unpack ( unUnitId exeUnitId )
+             binDirs = [ quoteArg ExpandVars scriptCfg $ getAbsolutePath $ installDir </> mkRelativePath ( "bin" </> Text.unpack ( unUnitId exeUnitId ) )
                        | exeUnitId <- puExeDepends ]
              setupDepDataDirs =
                dataDirs scriptCfg paths
@@ -128,8 +127,8 @@ setupPackage verbosity
                  ]
          logMessage verbosity Verbose $
            "Compiling Setup.hs for " <> pkgNameVer
-         callProcess $
-           CP { cwd          = "."
+         callProcess @Pkg $
+           CP { cwd          = workDir </> buildPkgDir
               , prog         = AbsPath ghcPath
               , args         = setupArgs
               , extraPATH    = binDirs
@@ -140,17 +139,21 @@ setupPackage verbosity
 
 -- | Find the @Setup.hs@/@Setup.lhs@ file to use,
 -- or create one using @main = defaultMain@ if none exist.
-findSetupHs :: FilePath -> IO FilePath
-findSetupHs root = trySetupsOrUseDefault [ "Setup.hs", "Setup.lhs" ]
+findSetupHs :: SymbolicPath CWD ( Dir Project )
+            -> SymbolicPath Project ( Dir Pkg )
+            -> IO ( RelativePath Pkg File )
+findSetupHs workDir root =
+  trySetupsOrUseDefault [ mkRelativePath "Setup.hs", mkRelativePath "Setup.lhs" ]
   where
+
     useDefaultSetupHs = do
-        let path = root </> "Setup.hs"
-        writeFile path defaultSetupHs
-        return "Setup.hs"
+        let path = root </> mkRelativePath "Setup.hs"
+        writeFile ( interpretSymbolicPath workDir path ) defaultSetupHs
+        return $ mkRelativePath "Setup.hs"
 
     try fname = do
         let path = root </> fname
-        exists <- doesFileExist path
+        exists <- doesFileExist ( interpretSymbolicPath workDir path )
         return $ if exists then Just fname else Nothing
 
     defaultSetupHs = unlines
@@ -159,7 +162,7 @@ findSetupHs root = trySetupsOrUseDefault [ "Setup.hs", "Setup.lhs" ]
         ]
 
     trySetupsOrUseDefault [] = useDefaultSetupHs
-    trySetupsOrUseDefault (setupPath:setups) = do
+    trySetupsOrUseDefault ( setupPath : setups ) = do
       res <- try setupPath
       case res of
         Nothing    -> trySetupsOrUseDefault setups
@@ -178,6 +181,7 @@ findSetupHs root = trySetupsOrUseDefault [ "Setup.hs", "Setup.lhs" ]
 -- registered in the package database.
 buildUnit :: Verbosity
           -> Compiler
+          -> SymbolicPath CWD ( Dir Project )
           -> BuildPaths ForBuild -- ^ Overall build directory structure.
           -> PkgDbDir   ForBuild -- ^ Package database directory (see 'getPkgDbDirForBuild').
           -> PkgDir     ForBuild -- ^ This package's directory (see 'getPkgDir').
@@ -187,6 +191,7 @@ buildUnit :: Verbosity
           -> BuildScript
 buildUnit verbosity
           ( Compiler { ghcPath, ghcPkgPath } )
+          workDir
           paths@( BuildPaths { installDir, prefix, logDir } )
           ( PkgDbDirForBuild
             { finalPkgDbDir
@@ -196,18 +201,21 @@ buildUnit verbosity
                      , mbHaddockArgs = mbUserHaddockArgs
                      , registerArgs  = userGhcPkgArgs } )
           plan unit@( ConfiguredUnit { puId, puDepends, puExeDepends } )
-  = let compName = Text.unpack $ cabalComponent ( puComponentName unit )
-        thisUnit'sId = Text.unpack ( unUnitId puId )
+  = let compName     = Text.unpack $ cabalComponent ( puComponentName unit )
+        thisUnit'sId = Text.unpack $ unUnitId puId
+        logPath :: Maybe ( AbsolutePath File )
         logPath
           | verbosity <= Quiet
           = Nothing
           | otherwise
-          = Just $ logDir </> thisUnit'sId
+          = Just $ logDir </> mkRelativePath thisUnit'sId
         unitPrintableName
           | verbosity >= Verbose
           = pkgNameVer <> ":" <> compName
           | otherwise
           = compName
+        setupDir :: SymbolicPath CWD ( Dir Pkg )
+        setupDir = workDir </> pkgDir
 
     in do
       scriptCfg <- askScriptConfig
@@ -222,7 +230,6 @@ buildUnit verbosity
               , let dep = lookupDependency unit depUnitId plan
               , dep_cu <- maybeToList $ configuredUnitMaybe dep
               ]
-              ++ [ ("prefix", quoteArg ExpandVars scriptCfg prefix) ]
 
       -- Configure
       let flagsArg = case puFlags unit of
@@ -230,7 +237,7 @@ buildUnit verbosity
               | flagSpecIsEmpty flags
               -> []
               | otherwise
-              -> [ "--flags=" <> quoteArg ExpandVars scriptCfg ( Text.unpack (showFlagSpec flags) ) ]
+              -> [ "--flags=" <> quoteArg ExpandVars scriptCfg ( Text.unpack $ showFlagSpec flags ) ]
 
           -- NB: make sure to update the readme after changing
           -- the arguments that are passed here.
@@ -255,10 +262,10 @@ buildUnit verbosity
           -- Arguments essential to the build; can't be overriden by the user.
           essentialConfigureArgs =
             [ "--exact-configuration"
-            , "--with-compiler", quoteArg ExpandVars scriptCfg ghcPath
-            , "--prefix"       , quoteArg ExpandVars scriptCfg prefix
+            , "--with-compiler", quoteArg ExpandVars scriptCfg ( getAbsolutePath ghcPath )
+            , "--prefix"       , quoteArg ExpandVars scriptCfg ( getAbsolutePath prefix )
             , "--cid="        <> Text.unpack ( unUnitId puId )
-            , "--package-db=" <> quoteArg ExpandVars scriptCfg finalPkgDbDir
+            , "--package-db=" <> quoteArg ExpandVars scriptCfg ( getAbsolutePath finalPkgDbDir )
             , "--datadir="    <> quoteArg EscapeVars scriptCfg ( "$prefix" </> "share" )
                 -- Keep datadir in sync with the 'dataDirs' function.
             , "--datasubdir=" <> pkgNameVer
@@ -280,17 +287,19 @@ buildUnit verbosity
           -- dependencies during the build.
           -- Keep this in sync with --bindir in essentialConfigureArgs.
           binDirs = [ quoteArg ExpandVars scriptCfg $
-                      installDir </> "bin" </> Text.unpack ( unUnitId exeUnitId )
+                      getAbsolutePath $
+                      installDir </> mkRelativePath ( "bin" </> Text.unpack ( unUnitId exeUnitId ) )
                     | exeUnitId <- puExeDepends ]
 
+          setupExe :: ProgPath Pkg
           setupExe = RelPath $ runCwdExe scriptCfg "Setup" -- relative to pkgDir
 
       logMessage verbosity Verbose $
         "Configuring " <> unitPrintableName
       logMessage verbosity Debug $
-        "Configure arguments:\n" <> unlines (map ("  " <>) configureArgs)
-      callProcess $
-        CP { cwd          = pkgDir
+        "Configure arguments:\n" <> unlines ( map ( "  " <> ) configureArgs )
+      callProcess @Pkg $
+        CP { cwd          = setupDir
            , prog         = setupExe
            , args         = "configure" : configureArgs
            , extraPATH    = binDirs
@@ -302,8 +311,8 @@ buildUnit verbosity
       -- Build
       logMessage verbosity Verbose $
         "Building " <> unitPrintableName
-      callProcess $
-        CP { cwd          = pkgDir
+      callProcess @Pkg $
+        CP { cwd          = setupDir
            , prog         = setupExe
            , args         = [ "build"
                             , "--builddir=" <> buildDir
@@ -318,8 +327,8 @@ buildUnit verbosity
       for_ mbUserHaddockArgs \ userHaddockArgs -> do
         logMessage verbosity Verbose $
           "Building documentation for " <> unitPrintableName
-        callProcess $
-          CP { cwd          = pkgDir
+        callProcess @Pkg $
+          CP { cwd          = setupDir
              , prog         = setupExe
              , args         = [ "haddock"
                               , setupVerbosity verbosity ]
@@ -334,12 +343,12 @@ buildUnit verbosity
        -- Copy
       logMessage verbosity Verbose $
         "Copying " <> unitPrintableName
-      callProcess $
-        CP { cwd          = pkgDir
+      callProcess @Pkg $
+        CP { cwd          = setupDir
            , prog         = setupExe
            , args         = [ "copy", setupVerbosity verbosity
                             , "--builddir=" <> buildDir
-                            , "--target-package-db=" <> quoteArg ExpandVars scriptCfg (installDir </> "package.conf")
+                            , "--target-package-db=" <> quoteArg ExpandVars scriptCfg (getAbsolutePath $ installDir </> mkRelativePath "package.conf")
                             ]
            , extraPATH    = []
            , extraEnvVars = setupEnvVars
@@ -359,8 +368,8 @@ buildUnit verbosity
                    , pkgRegsFile ]
 
           -- Setup register
-          callProcess $
-            CP { cwd          = pkgDir
+          callProcess @Pkg $
+            CP { cwd          = setupDir
                , prog         = setupExe
                , args         = [ "register", setupVerbosity verbosity
                                 , "--builddir=" <> buildDir
@@ -378,17 +387,17 @@ buildUnit verbosity
           logMessage verbosity Verbose $
            mconcat [ "Registering ", unitPrintableName
                    , " in package database at:\n"
-                   , finalPkgDbDir ]
+                   , getAbsolutePath finalPkgDbDir ]
 
           -- ghc-pkg register
-          callProcess $
-            CP { cwd          = pkgDir
+          callProcess @Pkg $
+            CP { cwd          = setupDir
                , prog         = AbsPath ghcPkgPath
                , args         = [ "register"
                                 , ghcPkgVerbosity verbosity
                                 , "--force" ]
                                 ++ userGhcPkgArgs
-                                ++ [ "--package-db", quoteArg ExpandVars scriptCfg finalPkgDbDir
+                                ++ [ "--package-db", quoteArg ExpandVars scriptCfg ( getAbsolutePath finalPkgDbDir )
                                    , pkgRegsFile ]
                , extraPATH    = []
                , extraEnvVars = []
@@ -456,12 +465,12 @@ data family PkgDbDir use
 
 data instance PkgDbDir ForPrep
   = PkgDbDirForPrep
-    { finalPkgDbDir  :: !FilePath
+    { finalPkgDbDir  :: !( AbsolutePath ( Dir PkgDb ) )
         -- ^ Installation package database directory.
     }
 data instance PkgDbDir ForBuild
   = PkgDbDirForBuild
-    { finalPkgDbDir :: !FilePath
+    { finalPkgDbDir :: !( AbsolutePath ( Dir PkgDb ) )
         -- ^ Installation package database directory.
     , finalPkgDbSem :: !QSem
         -- ^ Semaphore controlling access to the installation
@@ -472,7 +481,7 @@ data instance PkgDbDir ForBuild
 -- to use.
 getPkgDbDirForPrep :: Paths ForPrep -> PkgDbDir ForPrep
 getPkgDbDirForPrep ( Paths { buildPaths = BuildPathsForPrep { installDir } } ) =
-    PkgDbDirForPrep { finalPkgDbDir = installDir </> "package.conf" }
+    PkgDbDirForPrep { finalPkgDbDir = installDir </> mkRelativePath "package.conf" }
 
 -- | Compute the paths of the package database directory we are going
 -- to use, and create some semaphores to control access to it
@@ -483,7 +492,7 @@ getPkgDbDirForBuild ( Paths { buildPaths = BuildPaths { installDir } } ) = do
   return $
     PkgDbDirForBuild { finalPkgDbDir, finalPkgDbSem }
     where
-      finalPkgDbDir = installDir </> "package.conf"
+      finalPkgDbDir = installDir </> mkRelativePath "package.conf"
 
 -- | The package @name-version@ string and its directory.
 type PkgDir :: PathUsability -> Type
@@ -491,7 +500,7 @@ data PkgDir use
   = PkgDir
     { pkgNameVer :: !String
         -- ^ Package @name-version@ string.
-    , pkgDir     :: !FilePath
+    , pkgDir     :: !( SymbolicPath Project ( Dir Pkg ) )
         -- ^ Package directory.
     }
 type role PkgDir representational
@@ -499,31 +508,26 @@ type role PkgDir representational
   -- a @PkgDir ForBuild@.
 
 -- | Compute the package directory location.
-getPkgDir :: FilePath
-              -- ^ Working directory
-              -- (used only to relativise paths to local packages).
-          -> Paths use
+getPkgDir :: Paths use
               -- ^ Overall directory structure to base the computation off.
           -> ConfiguredUnit
               -- ^ Any unit from the package in question.
           -> PkgDir use
-getPkgDir workDir ( Paths { fetchDir } )
+getPkgDir ( Paths { fetchDir } )
           ( ConfiguredUnit { puPkgName, puVersion, puPkgSrc } )
   = PkgDir { pkgNameVer, pkgDir }
     where
       pkgNameVer = Text.unpack $ pkgNameVersion puPkgName puVersion
       pkgDir
         | Local dir <- puPkgSrc
-        = makeRelative workDir dir
-          -- Give local packages paths relative to the working directory,
-          -- to enable relocatable build scripts.
+        = dir
         | otherwise
-        = fetchDir </> pkgNameVer
+        = fetchDir </> mkRelativePath pkgNameVer
 
 -- | Command to run an executable located the current working directory.
-runCwdExe :: ScriptConfig -> FilePath -> FilePath
+runCwdExe :: ScriptConfig -> String -> SymbolicPath from File
 runCwdExe ( ScriptConfig { scriptOutput, scriptStyle } )
-  = pre . ext
+  = mkSymbolicPath . pre . ext
   where
     pre
       | Run <- scriptOutput
@@ -544,6 +548,6 @@ dataDirs :: ScriptConfig
 dataDirs scriptCfg ( BuildPaths { installDir } ) units =
     [ ( mangledPkgName puPkgName <> "_datadir"
       , quoteArg ExpandVars scriptCfg $
-          installDir </> "share" </> Text.unpack (pkgNameVersion puPkgName puVersion) )
+          getAbsolutePath $ installDir </> mkRelativePath ( "share" </> Text.unpack ( pkgNameVersion puPkgName puVersion ) ) )
         -- Keep this in sync with --datadir in essentialConfigureArgs.
     | ConfiguredUnit { puPkgName, puVersion } <- units ]

--- a/src/BuildEnv/Path.hs
+++ b/src/BuildEnv/Path.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module BuildEnv.Path
+  ( SymbolicPath, RelativePath, AbsolutePath
+  , FileOrDir(..)
+  , CWD, Pkg, PkgDb, Project
+  , Tmp, Logs, Fetch, Prefix, Install
+
+  , sameDirectory
+  , mkSymbolicPath
+  , mkRelativePath
+  , mkAbsolutePath
+
+  , interpretSymbolicPath
+  , getSymbolicPath
+  , getAbsolutePath
+  , absoluteSymbolicPath
+  , makeAbsolute
+
+  , (<.>), (</>)
+  )
+  where
+
+-- base
+import Data.Kind
+  ( Type )
+
+-- directory
+import qualified System.Directory as Directory
+
+-- filepath
+import qualified System.FilePath as FilePath
+
+--------------------------------------------------------------------------------
+
+-- | A type-level symbolic name, to an abstract file or directory
+-- (e.g. the Cabal package directory).
+data FileOrDir
+  = -- | A file (with no further information).
+    File
+  | -- | The abstract name of a directory or category of directories,
+    -- e.g. the package directory or a source directory.
+    Dir Type
+
+-- | Is this symbolic path allowed to be absolute, or must it be relative?
+data AllowAbsolute
+  = -- | The path may be absolute, or it may be relative.
+    AllowAbsolute
+  | -- | The path must be relative.
+    OnlyRelative
+
+-- | A symbolic path, possibly relative to an abstract location specified
+-- by the @from@ type parameter.
+--
+-- They are *symbolic*, which means we cannot perform any 'IO'
+-- until we interpret them (using e.g. 'interpretSymbolicPath').
+type SymbolicPathX :: AllowAbsolute -> Type -> FileOrDir -> Type
+newtype SymbolicPathX allowAbsolute from to = SymbolicPath FilePath
+  deriving newtype Show
+type role SymbolicPathX nominal nominal nominal
+
+-- | A symbolic relative path, relative to an abstract location specified
+-- by the @from@ type parameter.
+--
+-- They are *symbolic*, which means we cannot perform any 'IO'
+-- until we interpret them (using e.g. 'interpretSymbolicPath').
+type RelativePath = SymbolicPathX 'OnlyRelative
+
+-- | A path which is either absolute or relative to the given abstract*
+-- location specified by the @from@ type parameter.
+--
+-- They are *symbolic*, which means we cannot perform any 'IO'
+-- until we interpret them (using e.g. 'interpretSymbolicPath').
+type SymbolicPath = SymbolicPathX 'AllowAbsolute
+
+-- | An absolute path, or a reference to a path from the PATH environment variable.
+type AbsolutePath :: FileOrDir -> Type
+newtype AbsolutePath to = AbsolutePath ( forall from. SymbolicPath from to )
+instance Show ( AbsolutePath to ) where
+  show ( AbsolutePath fp ) = show fp
+
+--------------------------------------------------------------------------------
+
+-- | Abstract directory: current working directory.
+data CWD
+
+-- | Abstract directory: project root for 'build-env' commands.
+data Project
+
+-- | Abstract directory: package directory (e.g. a directory containing the @.cabal@ file).
+data Pkg
+
+-- | Abstract directory: package database directory (e.g. a directory containing a @package.conf@ file).
+data PkgDb
+
+-- | Abstract temporary directory.
+data Tmp
+
+-- | Abstract directory for logs.
+data Logs
+
+-- | Abstract directory: fetched sources directory.
+data Fetch
+
+-- | Abstract directory: prefix.
+data Prefix
+
+-- | Abstract directory: installation directory.
+data Install
+
+--------------------------------------------------------------------------------
+
+mkSymbolicPath :: FilePath -> SymbolicPath from to
+mkSymbolicPath = SymbolicPath
+
+mkRelativePath :: FilePath -> RelativePath from to
+mkRelativePath = SymbolicPath
+
+mkAbsolutePath :: FilePath -> AbsolutePath to
+mkAbsolutePath fp = AbsolutePath ( mkSymbolicPath fp )
+
+sameDirectory :: SymbolicPathX allowAbsolute from to
+sameDirectory = SymbolicPath "."
+
+getSymbolicPath :: SymbolicPathX allowAbsolute from to -> FilePath
+getSymbolicPath ( SymbolicPath p ) = p
+
+getAbsolutePath :: AbsolutePath to -> FilePath
+getAbsolutePath ( AbsolutePath p ) = getSymbolicPath p
+
+absoluteSymbolicPath :: AbsolutePath to -> SymbolicPath from to
+absoluteSymbolicPath ( AbsolutePath p ) = p
+
+-- | Interpret a symbolic path with respect to the given directory.
+--
+-- Use this function before directly interacting with the file system in order
+-- to take into account a working directory argument.
+interpretSymbolicPath :: SymbolicPath CWD ( Dir dir ) -> SymbolicPathX allowAbsolute dir to -> FilePath
+interpretSymbolicPath ( SymbolicPath workDir ) ( SymbolicPath p ) =
+  if workDir == "."
+  then p -- NB: this just avoids creating paths of the form "./././blah".
+  else workDir </> p
+          -- Note that this properly handles an absolute symbolic path,
+          -- because if @q@ is absolute, then @p </> q = q@.
+
+-- | Make the given 'SymbolicPath' absolute.
+makeAbsolute :: SymbolicPath CWD ( Dir dir ) -> SymbolicPath dir to -> IO ( AbsolutePath to )
+makeAbsolute workDir path =
+  mkAbsolutePath <$> Directory.makeAbsolute ( interpretSymbolicPath workDir path )
+
+-------------------------------------------------------------------------------
+
+-- * Composition
+
+-------------------------------------------------------------------------------
+
+infixr 7 <.>
+
+-- | Types that support 'System.FilePath.<.>'.
+class FileLike p where
+  -- | Like 'System.FilePath.<.>', but also supporting symbolic paths.
+  (<.>) :: p -> String -> p
+
+instance FileLike FilePath where
+  (<.>) = (FilePath.<.>)
+
+instance p ~ File => FileLike ( SymbolicPathX allowAbsolute dir p ) where
+  SymbolicPath p <.> ext = SymbolicPath ( p <.> ext )
+
+instance p ~ File => FileLike ( AbsolutePath p ) where
+  p <.> ext = mkAbsolutePath ( getAbsolutePath p <.> ext )
+
+infixr 5 </>
+
+-- | Types that support 'System.FilePath.</>'.
+class PathLike p q r | q r -> p, p q -> r where
+  -- | Like 'System.FilePath.</>', but also supporting symbolic paths.
+  (</>) :: p -> q -> r
+
+instance ( q ~ FilePath ) => PathLike FilePath q FilePath where
+  (</>) = (FilePath.</>)
+
+-- | This instance ensures we don't accidentally discard a symbolic path
+-- in a 'System.FilePath.</>' operation due to the second path being absolute.
+--
+-- (Recall that @a </> b = b@ whenever @b@ is absolute.)
+instance
+  (b1 ~ 'Dir b2, a3 ~ a1, c2 ~ c3)
+  => PathLike
+      ( SymbolicPathX allowAbsolute a1 b1 )
+      ( SymbolicPathX midAbsolute   b2 c2 )
+      ( SymbolicPathX allowAbsolute a3 c3 )
+  where
+  SymbolicPath p1 </> SymbolicPath p2 =
+    if p1 == "."
+    then SymbolicPath p2 -- NB: this just avoids creating paths of the form "./././blah".
+    else SymbolicPath (p1 </> p2)
+
+instance
+  ( b1 ~ 'Dir b2, c2 ~ c3, midAbsolute ~ OnlyRelative )
+  => PathLike
+      ( AbsolutePath                 b1 )
+      ( SymbolicPathX midAbsolute b2 c2 )
+      ( AbsolutePath                 c3 )
+  where
+  AbsolutePath (SymbolicPath p1) </> SymbolicPath p2 =
+    mkAbsolutePath (p1 </> p2)

--- a/tests/WorkDirDirect/wd/.gitignore
+++ b/tests/WorkDirDirect/wd/.gitignore
@@ -1,0 +1,2 @@
+sources/
+install/

--- a/tests/WorkDirScript/.gitignore
+++ b/tests/WorkDirScript/.gitignore
@@ -1,0 +1,1 @@
+build_hash.sh

--- a/tests/WorkDirScript/wd/.gitignore
+++ b/tests/WorkDirScript/wd/.gitignore
@@ -1,0 +1,2 @@
+sources/
+install/


### PR DESCRIPTION
This PR avoids changing the process-global working directory when invoking `build-env`.
